### PR TITLE
Pagination 手动设置 currentPage, pageSize 不触发相应事件

### DIFF
--- a/components/pagination/jumper.tsx
+++ b/components/pagination/jumper.tsx
@@ -17,12 +17,11 @@ export default defineComponent({
             type: Number,
             default: 0,
         },
-        change: {
-            type: Function,
-            default: null,
-        },
     },
-    setup(props) {
+    emits: [
+        'change'
+    ],
+    setup(props, { emit }) {
         const current = ref();
         const { total } = toRefs(props);
         const handleChange = (val: string) => {
@@ -33,7 +32,7 @@ export default defineComponent({
             const currentPage =
                 cur < 1 ? 1 : cur > total.value ? total.value : cur;
             current.value = currentPage;
-            props.change(currentPage);
+            emit('change', currentPage);
         };
         const { t } = useLocale()
         return () => (

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -73,6 +73,7 @@
             border-style: solid;
             border-width: 1px;
             border-radius: var(--f-pager-item-border-radius);
+            box-sizing: border-box;
             cursor: pointer;
 
             &:hover {

--- a/components/pagination/useSpecialModel.ts
+++ b/components/pagination/useSpecialModel.ts
@@ -1,0 +1,54 @@
+import { ref, watch, computed, WritableComputedRef } from 'vue';
+import { isEqual } from 'lodash-es';
+
+export default (
+    props: Record<string, any>,
+    emit: any,
+    config: {
+        prop?: string;
+        isEqual?: boolean;
+    } = {
+        prop: 'modelValue',
+        isEqual: false,
+    },
+    callback: Function
+): [WritableComputedRef<any>, (val: any) => void] => {
+    const usingProp = config?.prop ?? 'modelValue';
+    const currentValue = ref(props[usingProp]);
+    const pureUpdateCurrentValue = (value: any) => {
+        if (
+            value === currentValue.value ||
+            (config.isEqual && isEqual(value, currentValue.value))
+        ) {
+            return;
+        }
+        currentValue.value = value;
+    };
+    const updateCurrentValue = (value: any) => {
+        if (value === currentValue.value) {
+            return;
+        }
+        pureUpdateCurrentValue(value);
+        emit(`update:${usingProp}`, value);
+        callback();
+    };
+
+    watch(
+        () => props[usingProp],
+        (val) => {
+            pureUpdateCurrentValue(val);
+        },
+    );
+
+    return [
+        computed({
+            get() {
+                return currentValue.value;
+            },
+            set(value) {
+                updateCurrentValue(value);
+            },
+        }),
+        updateCurrentValue,
+    ];
+};

--- a/docs/.vitepress/components/pagination/index.md
+++ b/docs/.vitepress/components/pagination/index.md
@@ -65,5 +65,5 @@ app.use(FPagination);
 
 | 事件名称 | 说明             | 回调参数        |
 | -------- | ---------------- | --------------- |
-| change    | 页码改变的回调，参数是改变后的页码及每页条数 | (currentPage, pageSize) => void |
-| pageSizeChange    | 页码改变的回调，参数是改变后的页码及每页条数 | (pageSize) => void |
+| change    | currentPage 或 pageSize 改变的回调，参数是改变后的页码及每页条数 | (currentPage, pageSize) => void |
+| pageSizeChange    | pageSize 改变的回调，参数是改变后的每页条数 | (pageSize) => void |


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications: 更新以后用户主动改变 currentPage, pageSize 将不会触发相应的事件。之前仅仅依赖监听 change / pageSizeChange 变化然后去请求接口的行为将需要在改变之后主动请求接口。

**Related issue (if exists):**


**Other information:**
