### PR TITLE
fix: FSelectCascader 兼容 showPath 时未匹配到值的初始化展示

### DIFF
--- a/components/cascader/cascader.tsx
+++ b/components/cascader/cascader.tsx
@@ -7,7 +7,6 @@ import { COMPONENT_NAME, CHECK_STRATEGY } from './const';
 import useData from './useData';
 import useState from './useState';
 import { cascaderProps, CASCADER_PROVIDE_KEY } from './props';
-import Scrollbar from '../scrollbar';
 import { handleParent, handleChildren } from './helper';
 
 import type { CascaderNodeKey } from './interface';
@@ -210,13 +209,11 @@ export default defineComponent({
 
         const renderMenu = (key: CascaderNodeKey) => {
             return (
-                <Scrollbar containerClass={`${prefixCls}-dropdown`} key={key}>
-                    <CascaderMenu
-                        menuKey={key}
-                        initialLoaded={initialLoaded.value}
-                        listEmptyText={listEmptyText.value}
-                    ></CascaderMenu>
-                </Scrollbar>
+                <CascaderMenu
+                    menuKey={key}
+                    initialLoaded={initialLoaded.value}
+                    listEmptyText={listEmptyText.value}
+                ></CascaderMenu>
             );
         };
         const renderMenus = (arr: CascaderNodeKey[]) =>

--- a/components/cascader/cascader.tsx
+++ b/components/cascader/cascader.tsx
@@ -150,7 +150,7 @@ export default defineComponent({
                   })
                 : arr;
         }
-        
+
         const checkNode = (val: CascaderNodeKey, event: Event) => {
             updateExpandedKeysBySelectOrCheck(val, event);
 

--- a/components/cascader/cascader.tsx
+++ b/components/cascader/cascader.tsx
@@ -1,17 +1,16 @@
 import { defineComponent, provide, watch, VNodeChild, computed } from 'vue';
-import { isFunction, isString, cloneDeep } from 'lodash-es';
+import { cloneDeep } from 'lodash-es';
 import getPrefixCls from '../_util/getPrefixCls';
 import { useTheme } from '../_theme/useTheme';
-import CascaderNode from './cascaderNode';
+import CascaderMenu from './cascaderMenu';
 import { COMPONENT_NAME, CHECK_STRATEGY } from './const';
 import useData from './useData';
 import useState from './useState';
 import { cascaderProps, CASCADER_PROVIDE_KEY } from './props';
 import Scrollbar from '../scrollbar';
-import LoadingOutlined from '../icon/LoadingOutlined';
 import { handleParent, handleChildren } from './helper';
 
-import type { InnerCascaderOption, CascaderNodeKey } from './interface';
+import type { CascaderNodeKey } from './interface';
 import { useLocale } from '../config-provider/useLocale';
 
 const prefixCls = getPrefixCls('cascader');
@@ -47,7 +46,7 @@ export default defineComponent({
             hasCheckLoaded,
         } = useState(props, { emit });
 
-        const { nodeList, getMenuNodes, menuKeys, initialLoaded } = useData({
+        const { transformData, nodeList, menuKeys, initialLoaded } = useData({
             props,
             currentExpandedKeys,
         });
@@ -205,60 +204,18 @@ export default defineComponent({
             hasChecked,
             hasLoaded,
             hasCheckLoaded,
+            transformData,
             nodeList,
         });
 
-        const renderNode = (node: InnerCascaderOption) => {
-            const itemSlots: {
-                [key: string]: () => VNodeChild | string;
-            } = {};
-            if (isFunction(node.prefix)) {
-                itemSlots.prefix = node.prefix;
-            }
-            if (isString(node.prefix)) {
-                itemSlots.prefix = () => node.prefix as string;
-            }
-            if (isFunction(node.suffix)) {
-                itemSlots.suffix = node.suffix;
-            }
-            if (isString(node.suffix)) {
-                itemSlots.suffix = () => node.suffix as string;
-            }
-            return (
-                <CascaderNode
-                    key={node.value}
-                    level={node.level}
-                    value={node.value}
-                    label={node.label}
-                    disabled={node.disabled}
-                    selectable={node.selectable}
-                    checkable={node.checkable}
-                    isLeaf={node.isLeaf}
-                    v-slots={itemSlots}
-                ></CascaderNode>
-            );
-        };
-        const renderNodes = (nodes: InnerCascaderOption[]) =>
-            nodes.map((node) => renderNode(node));
-
         const renderMenu = (key: CascaderNodeKey) => {
-            const nodes = getMenuNodes(key);
-
             return (
                 <Scrollbar containerClass={`${prefixCls}-dropdown`} key={key}>
-                    <div class={`${prefixCls}-menu`} role="cascader-menu">
-                        {nodes.length ? (
-                            renderNodes(nodes)
-                        ) : initialLoaded.value ? (
-                            <div class={`${prefixCls}-null`}>
-                                {listEmptyText.value}
-                            </div>
-                        ) : (
-                            <div class={`${prefixCls}-loading`}>
-                                <LoadingOutlined />
-                            </div>
-                        )}
-                    </div>
+                    <CascaderMenu
+                        menuKey={key}
+                        initialLoaded={initialLoaded.value}
+                        listEmptyText={listEmptyText.value}
+                    ></CascaderMenu>
                 </Scrollbar>
             );
         };

--- a/components/cascader/cascaderMenu.tsx
+++ b/components/cascader/cascaderMenu.tsx
@@ -1,0 +1,78 @@
+import { defineComponent, ExtractPropTypes, PropType, VNodeChild } from 'vue';
+import { isFunction, isString } from 'lodash-es';
+import getPrefixCls from '../_util/getPrefixCls';
+import LoadingOutlined from '../icon/LoadingOutlined';
+import { COMPONENT_NAME } from './const';
+import useCascaderMenu from './useCascaderMenu';
+import { InnerCascaderOption } from './interface';
+import CascaderNode from './cascaderNode';
+
+const prefixCls = getPrefixCls('cascader');
+
+const cascaderMenuProps = {
+    menuKey: {
+        type: [String, Number] as PropType<string | number>,
+        required: true,
+    },
+    initialLoaded: Boolean,
+    listEmptyText: String,
+} as const;
+
+export type CascaderMenuProps = Partial<
+    ExtractPropTypes<typeof cascaderMenuProps>
+>;
+
+export default defineComponent({
+    name: COMPONENT_NAME.CASCADER_MENU,
+    props: cascaderMenuProps,
+    setup(props) {
+        const { menuNodes } = useCascaderMenu(props);
+
+        const renderNode = (node: InnerCascaderOption) => {
+            const itemSlots: {
+                [key: string]: () => VNodeChild | string;
+            } = {};
+            if (isFunction(node.prefix)) {
+                itemSlots.prefix = node.prefix;
+            }
+            if (isString(node.prefix)) {
+                itemSlots.prefix = () => node.prefix as string;
+            }
+            if (isFunction(node.suffix)) {
+                itemSlots.suffix = node.suffix;
+            }
+            if (isString(node.suffix)) {
+                itemSlots.suffix = () => node.suffix as string;
+            }
+            return (
+                <CascaderNode
+                    key={node.value}
+                    level={node.level}
+                    value={node.value}
+                    label={node.label}
+                    disabled={node.disabled}
+                    selectable={node.selectable}
+                    checkable={node.checkable}
+                    isLeaf={node.isLeaf}
+                    v-slots={itemSlots}
+                ></CascaderNode>
+            );
+        };
+        const renderNodes = (nodes: InnerCascaderOption[]) =>
+            nodes.map((node) => renderNode(node));
+
+        return () => (
+            <div class={`${prefixCls}-menu`} role="cascader-menu">
+                {menuNodes.value.length ? (
+                    renderNodes(menuNodes.value)
+                ) : props.initialLoaded ? (
+                    <div class={`${prefixCls}-null`}>{props.listEmptyText}</div>
+                ) : (
+                    <div class={`${prefixCls}-loading`}>
+                        <LoadingOutlined />
+                    </div>
+                )}
+            </div>
+        );
+    },
+});

--- a/components/cascader/cascaderMenu.tsx
+++ b/components/cascader/cascaderMenu.tsx
@@ -6,8 +6,9 @@ import { COMPONENT_NAME } from './const';
 import useCascaderMenu from './useCascaderMenu';
 import { InnerCascaderOption } from './interface';
 import CascaderNode from './cascaderNode';
+import Scrollbar from '../scrollbar';
 
-const prefixCls = getPrefixCls('cascader');
+const prefixCls = getPrefixCls('cascader-menu');
 
 const cascaderMenuProps = {
     menuKey: {
@@ -62,17 +63,24 @@ export default defineComponent({
             nodes.map((node) => renderNode(node));
 
         return () => (
-            <div class={`${prefixCls}-menu`} role="cascader-menu">
-                {menuNodes.value.length ? (
-                    renderNodes(menuNodes.value)
-                ) : props.initialLoaded ? (
-                    <div class={`${prefixCls}-null`}>{props.listEmptyText}</div>
-                ) : (
-                    <div class={`${prefixCls}-loading`}>
-                        <LoadingOutlined />
-                    </div>
-                )}
-            </div>
+            <Scrollbar
+                containerClass={`${prefixCls}-dropdown`}
+                key={props.menuKey}
+            >
+                <div class={`${prefixCls}`} role="cascader-menu">
+                    {menuNodes.value.length ? (
+                        renderNodes(menuNodes.value)
+                    ) : props.initialLoaded ? (
+                        <div class={`${prefixCls}-null`}>
+                            {props.listEmptyText}
+                        </div>
+                    ) : (
+                        <div class={`${prefixCls}-loading`}>
+                            <LoadingOutlined />
+                        </div>
+                    )}
+                </div>
+            </Scrollbar>
         );
     },
 });

--- a/components/cascader/cascaderNode.tsx
+++ b/components/cascader/cascaderNode.tsx
@@ -188,7 +188,11 @@ export default defineComponent({
                     onClick={handleClickSwitcher}
                     onMouseenter={handleHoverSwitcher}
                 >
-                    {isInitLoading.value || isLoading.value ? <LoadingOutlined /> : <RightOutlined />}
+                    {isInitLoading.value || isLoading.value ? (
+                        <LoadingOutlined />
+                    ) : (
+                        <RightOutlined />
+                    )}
                 </span>
             );
         };

--- a/components/cascader/cascaderNode.tsx
+++ b/components/cascader/cascaderNode.tsx
@@ -59,6 +59,7 @@ export default defineComponent({
         const {
             root,
             isExpanded,
+            isInitLoading,
             isSelected,
             isChecked,
             isIndeterminate,
@@ -97,7 +98,7 @@ export default defineComponent({
 
         const isLoading = ref(false);
         const handleClickSwitcher = async (event: Event) => {
-            if (isLoading.value) {
+            if (isInitLoading.value || isLoading.value) {
                 return;
             }
             const node = root.nodeList[props.value];
@@ -187,7 +188,7 @@ export default defineComponent({
                     onClick={handleClickSwitcher}
                     onMouseenter={handleHoverSwitcher}
                 >
-                    {isLoading.value ? <LoadingOutlined /> : <RightOutlined />}
+                    {isInitLoading.value || isLoading.value ? <LoadingOutlined /> : <RightOutlined />}
                 </span>
             );
         };

--- a/components/cascader/const.ts
+++ b/components/cascader/const.ts
@@ -1,5 +1,6 @@
 export const COMPONENT_NAME = {
     CASCADER: 'FCascader',
+    CASCADER_MENU: 'FCascaderMenu',
     CASCADER_NODE: 'FCascaderNode',
 };
 

--- a/components/cascader/props.ts
+++ b/components/cascader/props.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes, PropType, InjectionKey } from 'vue';
+import type { ExtractPropTypes, PropType, InjectionKey, Ref } from 'vue';
 import { CHECK_STRATEGY, EXPAND_TRIGGER } from './const';
 import { extractPropsDefaultValue } from '../_util/utils';
 
@@ -119,6 +119,7 @@ export interface CascaderInst {
         value: CascaderNodeKey,
         nodeList: CascaderNodeList,
     ) => boolean;
+    transformData: Ref<CascaderNodeKey[]>;
     nodeList: {
         [key: string]: InnerCascaderOption;
     };

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -13,10 +13,6 @@
     .text();
     position: relative;
     display: flex;
-    &-dropdown {
-        max-height: @select-dropdown-max-height;
-        padding: @padding-xs 0;
-    }
     &-menu {
         position: relative;
         box-sizing: border-box;
@@ -26,7 +22,13 @@
         border-right: var(--f-border-width-base) var(--f-border-style-base)
             var(--f-border-color-split);
     }
-    &-null,&-loading {
+    &-menu-dropdown {
+        max-height: @select-dropdown-max-height;
+        padding: @padding-xs 0;
+    }
+
+    &-menu-null,
+    &-menu-loading {
         text-align: center;
     }
     &-node {
@@ -44,7 +46,8 @@
         &.is-expanded {
             --f-cascader-node-content-wrapper-bg-color: @cascader-selected-background-color;
         }
-        &.is-selected, &.is-checked {
+        &.is-selected,
+        &.is-checked {
             --f-cascader-node-content-wrapper-color: var(--f-primary-color);
         }
         &.is-disabled {
@@ -53,7 +56,8 @@
             );
             --f-cascader-node-content-wrapper-bg-color: var(--f-white);
             cursor: not-allowed;
-            &.is-selected, &.is-checked {
+            &.is-selected,
+            &.is-checked {
                 --f-cascader-node-content-wrapper-color: var(
                     --f-text-color-disabled
                 );
@@ -67,7 +71,8 @@
         align-items: center;
         justify-content: center;
     }
-    &-node-checkbox, &-node-radio {
+    &-node-checkbox,
+    &-node-radio {
         margin-right: @padding-xs;
     }
     &-node-switcher {
@@ -92,7 +97,9 @@
         }
         &-label {
             flex-grow: 1;
-            max-width: calc(@select-dropdown-max-width - @data-input-height-base);
+            max-width: calc(
+                @select-dropdown-max-width - @data-input-height-base
+            );
         }
         &-suffix {
             display: inline-flex;

--- a/components/cascader/useCascaderMenu.ts
+++ b/components/cascader/useCascaderMenu.ts
@@ -1,0 +1,34 @@
+import { inject, computed } from 'vue';
+import { CASCADER_PROVIDE_KEY } from './props';
+
+import type { CascaderMenuProps } from './cascaderMenu';
+import { InnerCascaderOption } from './interface';
+import { ROOT_MENU_KEY } from './const';
+
+export default (props: CascaderMenuProps) => {
+    const root = inject(CASCADER_PROVIDE_KEY);
+
+    const menuNodes = computed(() => {
+        let nodes: InnerCascaderOption[] = [];
+
+        if (props.menuKey === ROOT_MENU_KEY) {
+            nodes = root.transformData.value
+                .filter((value) => {
+                    const node = root.nodeList[value];
+                    return node.indexPath.length === 1;
+                })
+                .map((value) => root.nodeList[value]);
+        } else {
+            nodes =
+                root.nodeList[props.menuKey]?.childrenValues.map(
+                    (value) => root.nodeList[value],
+                ) || [];
+        }
+
+        return nodes;
+    });
+
+    return {
+        menuNodes,
+    };
+};

--- a/components/cascader/useCascaderNode.ts
+++ b/components/cascader/useCascaderNode.ts
@@ -8,6 +8,9 @@ export default (props: CascaderNodeProps) => {
     const root = inject(CASCADER_PROVIDE_KEY);
 
     const isExpanded = computed(() => root.nodeList[props.value].isExpanded);
+    const isInitLoading = computed(
+        () => root.nodeList[props.value].isInitLoading,
+    );
     const isSelected = computed(() => root.hasSelected(props.value));
     const isChecked = computed(() => root.hasChecked(props.value));
 
@@ -43,6 +46,7 @@ export default (props: CascaderNodeProps) => {
     return {
         root,
         isExpanded,
+        isInitLoading,
         isSelected,
         isChecked,
         isIndeterminate,

--- a/components/select-cascader/helper.ts
+++ b/components/select-cascader/helper.ts
@@ -128,3 +128,24 @@ export const getNotMatchedPathByKey = (
 
     return path;
 };
+
+export const getExpandedKeysByCurrentValue = (
+    currentValue: CascaderNodeKey | CascaderNodeKey[] | CascaderNodeKey[][],
+    props: CascaderProps,
+) => {
+    const keys: CascaderNodeKey[] = [];
+
+    if (props.multiple) {
+        return keys;
+    }
+    if (!props.emitPath) {
+        return keys;
+    }
+    if (!isArray(currentValue)) {
+        return keys;
+    }
+    if (currentValue.length < 2) {
+        return keys;
+    }
+    return [...currentValue.slice(0, currentValue.length - 1)];
+};

--- a/components/select-cascader/helper.ts
+++ b/components/select-cascader/helper.ts
@@ -1,6 +1,10 @@
 import { isArray } from 'lodash-es';
 
-import type { CascaderNodeList, CascaderNodeKey } from '../cascader/interface';
+import type {
+    CascaderNodeList,
+    CascaderNodeKey,
+    CascaderOption,
+} from '../cascader/interface';
 import { CascaderProps } from '../cascader/props';
 
 export const getCurrentValueByKeys = (
@@ -58,4 +62,69 @@ export const getKeysByCurrentValue = (
             return [currentValue];
         }
     }
+};
+
+export const getNotMatchedPathByKey = (
+    currentValue: CascaderNodeKey | CascaderNodeKey[] | CascaderNodeKey[][],
+    props: CascaderProps,
+    key: CascaderNodeKey,
+) => {
+    let path: CascaderOption[] = [];
+    if (currentValue === null) {
+        return path;
+    }
+    if (props.multiple) {
+        const keyIndex = (
+            currentValue as CascaderNodeKey[] | CascaderNodeKey[][]
+        ).findIndex((value) => {
+            if (props.emitPath && isArray(value)) {
+                return value.includes(key);
+            } else {
+                return value === key;
+            }
+        });
+        if (keyIndex > -1) {
+            const keyValue = (
+                currentValue as CascaderNodeKey[] | CascaderNodeKey[][]
+            )[keyIndex];
+
+            if (props.emitPath && isArray(keyValue)) {
+                path = (keyValue as CascaderNodeKey[]).map((value) => {
+                    return {
+                        value,
+                        label: value as string,
+                    };
+                });
+            } else {
+                path = [
+                    {
+                        value: keyValue as CascaderNodeKey,
+                        label: keyValue as string,
+                    },
+                ];
+            }
+        }
+    } else {
+        if (props.emitPath && isArray(currentValue)) {
+            if ((currentValue as CascaderNodeKey[]).includes(key)) {
+                path = (currentValue as CascaderNodeKey[]).map((value) => {
+                    return {
+                        value,
+                        label: value as string,
+                    };
+                });
+            }
+        } else {
+            if (key === currentValue) {
+                path = [
+                    {
+                        value: currentValue as CascaderNodeKey,
+                        label: currentValue as string,
+                    },
+                ];
+            }
+        }
+    }
+
+    return path;
 };

--- a/components/select-cascader/helper.ts
+++ b/components/select-cascader/helper.ts
@@ -129,23 +129,19 @@ export const getNotMatchedPathByKey = (
     return path;
 };
 
-export const getExpandedKeysByCurrentValue = (
-    currentValue: CascaderNodeKey | CascaderNodeKey[] | CascaderNodeKey[][],
-    props: CascaderProps,
+export const getExpandedKeysBySelectedKeys = (
+    nodeList: CascaderNodeList,
+    selectedKeys: CascaderNodeKey[] = [],
 ) => {
-    const keys: CascaderNodeKey[] = [];
-
-    if (props.multiple) {
-        return keys;
+    const selectedNode = (selectedKeys[0] && nodeList[selectedKeys[0]]) || null;
+    if (selectedNode) {
+        return [
+            ...selectedNode.indexPath.slice(
+                0,
+                selectedNode.indexPath.length - 1,
+            ),
+        ];
+    } else {
+        return [];
     }
-    if (!props.emitPath) {
-        return keys;
-    }
-    if (!isArray(currentValue)) {
-        return keys;
-    }
-    if (currentValue.length < 2) {
-        return keys;
-    }
-    return [...currentValue.slice(0, currentValue.length - 1)];
 };

--- a/components/select-cascader/selectCascader.vue
+++ b/components/select-cascader/selectCascader.vue
@@ -75,6 +75,7 @@ import {
     getCurrentValueByKeys,
     getKeysByCurrentValue,
     getNotMatchedPathByKey,
+    getExpandedKeysByCurrentValue,
 } from './helper';
 import {
     getCascadeChildrenByKeys,
@@ -150,8 +151,15 @@ export default defineComponent({
         const cascaderSelectable = computed(() => !props.multiple);
         const cascaderCheckable = computed(() => props.multiple);
         const selectedKeys = computed(() => {
-            if (!props.multiple)
+            if (!props.multiple) {
                 return getKeysByCurrentValue(currentValue.value, props);
+            }
+            return [];
+        });
+        const expandedKeys = computed(() => {
+            if (!props.multiple) {
+                return getExpandedKeysByCurrentValue(currentValue.value, props);
+            }
             return [];
         });
         const checkedKeys = computed(() => {
@@ -349,6 +357,7 @@ export default defineComponent({
             blur,
             cascaderSelectable,
             selectedKeys,
+            expandedKeys,
             cascaderCheckable,
             handleSelect,
             handleCheck,

--- a/components/select-cascader/selectCascader.vue
+++ b/components/select-cascader/selectCascader.vue
@@ -75,7 +75,7 @@ import {
     getCurrentValueByKeys,
     getKeysByCurrentValue,
     getNotMatchedPathByKey,
-    getExpandedKeysByCurrentValue,
+    getExpandedKeysBySelectedKeys,
 } from './helper';
 import {
     getCascadeChildrenByKeys,
@@ -158,7 +158,10 @@ export default defineComponent({
         });
         const expandedKeys = computed(() => {
             if (!props.multiple) {
-                return getExpandedKeysByCurrentValue(currentValue.value, props);
+                return getExpandedKeysBySelectedKeys(
+                    nodeList.value,
+                    selectedKeys.value as CascaderNodeKey[],
+                );
             }
             return [];
         });

--- a/components/select-cascader/selectCascader.vue
+++ b/components/select-cascader/selectCascader.vue
@@ -71,7 +71,11 @@ import SelectTrigger from '../select-trigger';
 import Cascader from '../cascader/cascader';
 import { selectProps } from '../select/props';
 import { cascaderProps } from '../cascader/props';
-import { getCurrentValueByKeys, getKeysByCurrentValue } from './helper';
+import {
+    getCurrentValueByKeys,
+    getKeysByCurrentValue,
+    getNotMatchedPathByKey,
+} from './helper';
 import {
     getCascadeChildrenByKeys,
     getCascadeParentByKeys,
@@ -302,7 +306,11 @@ export default defineComponent({
                     const { value, label, path } = nodeList.value[curValue] || {
                         value: curValue,
                         label: curValue,
-                        path: [],
+                        path: getNotMatchedPathByKey(
+                            currentValue.value,
+                            props,
+                            curValue,
+                        ),
                     };
                     const formatLabel = props.showPath
                         ? (path as CascaderOption[])

--- a/docs/.vitepress/components/selectCascader/async.vue
+++ b/docs/.vitepress/components/selectCascader/async.vue
@@ -8,6 +8,7 @@
                 clearable
                 remote
                 emitPath
+                showPath
                 @change="handleChange"
             ></FSelectCascader>
         </FFormItem>

--- a/docs/.vitepress/components/selectCascader/index.md
+++ b/docs/.vitepress/components/selectCascader/index.md
@@ -32,7 +32,7 @@ app.use(FSelectCascader);
 
 ### emitPath 返回节点菜单路径
 
-适用于异步加载初始化展示的场景。
+适用于异步加载初始化展示等场景。
 
 --EMITPATH
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update
-   [ ] Refactor
-   [ ] Docs
-   [ ] Build-related changes
-   [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

-   [ ] Yes
-   [x] No

If yes, please describe the impact and migration path for existing applications:

**Related issue (if exists):**

**Other information:**

showPath时，若未匹配到值，增加初始化展示的处理

