### PR TITLE
break:  Tree 组件 checkStrictly 影响  checkedKeys 逻辑 

### DIFF
--- a/components/select-tree/selectTree.vue
+++ b/components/select-tree/selectTree.vue
@@ -138,7 +138,6 @@ import Tree from '../tree/tree';
 import Scrollbar from '../scrollbar/scrollbar.vue';
 import { selectProps } from '../select/props';
 import { treeProps } from '../tree/props';
-import { getChildrenByValues, getParentByValues } from './helper';
 
 import type { SelectValue } from '../select/interface';
 import type {
@@ -222,24 +221,7 @@ export default defineComponent({
         });
         const checkedKeys = computed(() => {
             if (props.multiple) {
-                if (!props.cascade) {
-                    return currentValue.value;
-                }
-                if (props.checkStrictly === 'all') {
-                    return currentValue.value;
-                }
-                if (props.checkStrictly === 'parent') {
-                    return getChildrenByValues(
-                        nodeList.value,
-                        currentValue.value,
-                    );
-                }
-                if (props.checkStrictly === 'child') {
-                    return getParentByValues(
-                        nodeList.value,
-                        currentValue.value,
-                    );
-                }
+                return currentValue.value;
             }
             return [];
         });

--- a/components/tree/helper.ts
+++ b/components/tree/helper.ts
@@ -1,4 +1,4 @@
-import type { TreeNodeKey, InnerTreeOption } from '../tree/interface';
+import type { TreeNodeKey, InnerTreeOption } from './interface';
 import { concat } from '../_util/utils';
 
 export const getChildrenByValues = (

--- a/components/tree/interface.ts
+++ b/components/tree/interface.ts
@@ -20,6 +20,7 @@ export interface InnerTreeOption extends TreeOption {
     level?: number;
     hasChildren?: boolean;
     indexPath?: TreeNodeKey[];
+    childrenPath?: TreeNodeKey[];
     children?: InnerTreeOption[];
     isExpanded?: Ref<boolean>;
     isChecked?: Ref<boolean>;

--- a/components/tree/tree.tsx
+++ b/components/tree/tree.tsx
@@ -1,26 +1,22 @@
-import {
-    defineComponent,
-    provide,
-    onMounted,
-    watch,
-    ref,
-    VNodeChild,
-} from 'vue';
-import { isFunction, isString, cloneDeep, debounce } from 'lodash-es';
+import { defineComponent, provide, VNodeChild } from 'vue';
+import { isFunction, isString } from 'lodash-es';
 import getPrefixCls from '../_util/getPrefixCls';
 import { useTheme } from '../_theme/useTheme';
 import VirtualList from '../virtual-list/virtualList';
 import TreeNode from './treeNode';
-import { COMPONENT_NAME, CHECK_STRATEGY } from './const';
+import { COMPONENT_NAME } from './const';
 import useData from './useData';
 import useState from './useState';
 import useDrag from './useDrag';
 import useFilter from './useFilter';
+import useExpand from './useExpand';
+import useSelect from './useSelect';
+import useCheck from './useCheck';
+import useCurrentData from './useCurrentData';
 
 import { treeProps, TREE_PROVIDE_KEY } from './props';
 
-import type { InnerTreeOption, TreeNodeKey } from './interface';
-import { concat } from '../_util/utils';
+import type { TreeNodeKey } from './interface';
 
 const prefixCls = getPrefixCls('tree');
 
@@ -48,6 +44,11 @@ export default defineComponent({
     setup(props, { emit, expose }) {
         useTheme();
 
+        const { nodeList, allKeys } = useData({
+            props,
+            emit,
+        });
+
         const {
             currentExpandedKeys,
             updateExpandedKeys,
@@ -56,223 +57,48 @@ export default defineComponent({
             currentSelectedKeys,
             updateSelectedKeys,
             hasSelected,
-        } = useState(props, { emit });
-
-        const { nodeList, transformData } = useData({
-            props,
-        });
+        } = useState({ props, emit });
 
         const { filter, filteredExpandedKeys, filteredKeys, isSearchingRef } =
-            useFilter(props, transformData, nodeList);
+            useFilter(props, allKeys, nodeList);
 
-        watch(
-            transformData,
-            () => {
-                emit('update:nodeList', nodeList);
-            },
-            {
-                immediate: true,
-            },
-        );
-
-        let checkingNode: InnerTreeOption;
-
-        function computeIndeterminate(key: TreeNodeKey) {
-            const node = nodeList.get(key);
-            if (node.hasChildren) {
-                if (node.isChecked.value) {
-                    node.isIndeterminate.value = false;
-                } else {
-                    node.isIndeterminate.value = node.children.some(
-                        (item) =>
-                            item.isChecked.value || item.isIndeterminate.value,
-                    );
-                }
-            } else {
-                node.isIndeterminate.value = false;
-            }
-        }
-
-        watch(currentCheckedKeys, (newKeys, oldKeys) => {
-            // 重置历史节点选择状态
-            oldKeys.forEach((key: TreeNodeKey) => {
-                const node = nodeList.get(key);
-                node.isChecked.value = false;
-            });
-            newKeys.forEach((key: TreeNodeKey) => {
-                const node = nodeList.get(key);
-                node.isChecked.value = true;
-            });
-            if (props.cascade) {
-                // 当选中某个节点时，只需要处理此节点相关上下节点状态
-                if (checkingNode) {
-                    const { indexPath } = checkingNode;
-                    indexPath.slice(0).reverse().forEach(computeIndeterminate);
-                    checkingNode.hasChildren &&
-                        checkingNode.childrenPath.forEach(
-                            (key: TreeNodeKey) => {
-                                const node = nodeList.get(key);
-                                node.isIndeterminate.value = false;
-                            },
-                        );
-                    checkingNode = null;
-                } else {
-                    transformData.value.forEach(computeIndeterminate);
-                }
-            }
+        const { expandNode, expandingNode } = useExpand({
+            allKeys,
+            isSearchingRef,
+            filteredExpandedKeys,
+            nodeList,
+            currentExpandedKeys,
+            updateExpandedKeys,
+            props,
+            emit,
         });
 
-        const currentData = ref<TreeNodeKey[]>([]);
-
-        let expandingNode: InnerTreeOption;
-
-        const _addNode = (
-            nodes: InnerTreeOption[],
-            res: TreeNodeKey[] = [],
-        ) => {
-            nodes.forEach((node) => {
-                res.push(node.value);
-                if (node.hasChildren && node.isExpanded.value) {
-                    _addNode(node.children, res);
-                }
-            });
-        };
-
-        const addNode = (nodes: InnerTreeOption[], index: number) => {
-            const res: TreeNodeKey[] = [];
-            _addNode(nodes, res);
-            const arr1 = currentData.value.slice(0, index);
-            const arr2 = currentData.value.slice(index);
-            concat(arr1, res);
-            concat(arr1, arr2);
-            currentData.value = arr1;
-        };
-
-        const deleteNode = (keys: TreeNodeKey[], index: number) => {
-            let len = 0;
-            keys.forEach((key) => {
-                if (key === currentData.value[index + len]) {
-                    len += 1;
-                }
-            });
-            currentData.value.splice(index, len);
-        };
-
-        const computeCurrentData = () => {
-            const res: TreeNodeKey[] = [];
-            const expandedKeys = isSearchingRef.value
-                ? filteredExpandedKeys.value
-                : currentExpandedKeys.value;
-
-            const keys = isSearchingRef.value
-                ? filteredKeys.value
-                : transformData.value;
-
-            if (expandingNode) {
-                // 展开后
-                if (expandingNode.isExpanded.value) {
-                    const index = currentData.value.indexOf(
-                        expandingNode.value,
-                    );
-                    addNode(expandingNode.children, index + 1);
-                } else {
-                    const index = currentData.value.indexOf(
-                        expandingNode.value,
-                    );
-                    deleteNode(expandingNode.childrenPath, index + 1);
-                }
-                expandingNode = null;
-                return;
-            }
-
-            // 缓存每个节点的展开状态，性能更优
-            keys.forEach((key) => {
-                const node = nodeList.get(key);
-                if (node.hasChildren) {
-                    node.isExpanded.value = expandedKeys.includes(key);
-                }
-                const indexPath = node.indexPath;
-                const len = indexPath.length;
-                let index = 0;
-                let parentExpanded = true;
-                while (index < len - 1) {
-                    const parentNode = nodeList.get(indexPath[index]);
-                    if (!parentNode.isExpanded.value) {
-                        parentExpanded = false;
-                        break;
-                    }
-                    index += 1;
-                }
-                if (parentExpanded) {
-                    res.push(key);
-                }
-            });
-            currentData.value = res;
-        };
-
-        watch(
-            [filteredExpandedKeys, filteredKeys],
-            debounce(() => {
-                if (!isSearchingRef.value) return;
-                computeCurrentData();
-            }, 10),
-        );
-
-        watch(
-            [currentExpandedKeys, transformData],
-            debounce(() => {
-                if (isSearchingRef.value) return;
-                computeCurrentData();
-            }, 10),
-            {
-                immediate: true,
-            },
-        );
-
-        watch([isSearchingRef], () => {
-            computeCurrentData();
+        const { selectNode } = useSelect({
+            nodeList,
+            currentSelectedKeys,
+            updateSelectedKeys,
+            props,
+            emit,
         });
 
-        const expandNode = (val: TreeNodeKey, event: Event) => {
-            if (isSearchingRef.value) {
-                const _value = cloneDeep(filteredExpandedKeys.value);
-                const index = _value.indexOf(val);
-                // 已经展开
-                if (index !== -1) {
-                    _value.splice(index, 1);
-                } else {
-                    _value.push(val);
-                }
-                filteredExpandedKeys.value = _value;
-                return;
-            }
-            const node = nodeList.get(val);
-            expandingNode = node;
-            let values: TreeNodeKey[] = cloneDeep(currentExpandedKeys.value);
-            const index = values.indexOf(val);
-            // 已经展开
-            if (index !== -1) {
-                values.splice(index, 1);
-                // 让动画早点动起来
-                node.isExpanded.value = false;
-            } else {
-                if (props.accordion) {
-                    values = values.filter((item) =>
-                        node.indexPath.includes(item),
-                    );
-                }
-                values.push(val);
-                // 让动画早点动起来
-                node.isExpanded.value = true;
-            }
-            updateExpandedKeys(values);
-            emit('expand', {
-                expandedKeys: values,
-                event,
-                node,
-                expanded: values.includes(val),
-            });
-        };
+        const { checkNode } = useCheck({
+            allKeys,
+            nodeList,
+            currentCheckedKeys,
+            updateCheckedKeys,
+            props,
+            emit,
+        });
+
+        const { currentData } = useCurrentData({
+            isSearchingRef,
+            filteredExpandedKeys,
+            currentExpandedKeys,
+            filteredKeys,
+            allKeys,
+            expandingNode,
+            nodeList,
+        });
 
         const {
             handleDragstart,
@@ -283,145 +109,6 @@ export default defineComponent({
             handleDrop,
             dragOverInfo,
         } = useDrag({ nodeList, emit, expandNode });
-
-        onMounted(() => {
-            if (
-                props.defaultExpandAll &&
-                currentExpandedKeys.value.length === 0
-            ) {
-                updateExpandedKeys(
-                    transformData.value.filter(
-                        (value) => !nodeList.get(value).isLeaf,
-                    ),
-                );
-            }
-        });
-
-        const selectNode = (val: TreeNodeKey, event: Event) => {
-            if (!props.selectable) {
-                return;
-            }
-            const node = nodeList.get(val);
-            const values = cloneDeep(currentSelectedKeys.value);
-            const index = values.indexOf(val);
-            if (props.multiple) {
-                if (index !== -1) {
-                    props.cancelable && values.splice(index, 1);
-                } else {
-                    values.push(val);
-                }
-            } else if (index !== -1) {
-                props.cancelable && values.splice(index, 1);
-            } else {
-                values[0] = val;
-            }
-            updateSelectedKeys(values);
-            emit('select', {
-                selectedKeys: values,
-                event,
-                node,
-                selected: values.includes(val),
-            });
-        };
-
-        function getCheckedKeys(arr: TreeNodeKey[]) {
-            return props.cascade
-                ? arr.filter((key) => {
-                      const node = nodeList.get(key);
-                      if (props.checkStrictly === CHECK_STRATEGY.ALL) {
-                          return true;
-                      }
-                      if (props.checkStrictly === CHECK_STRATEGY.PARENT) {
-                          return (
-                              node.indexPath.filter((path) =>
-                                  arr.includes(path),
-                              ).length === 1
-                          );
-                      }
-                      if (props.checkStrictly === CHECK_STRATEGY.CHILD) {
-                          return node.isLeaf;
-                      }
-                      return true;
-                  })
-                : arr;
-        }
-        function handleChildren(
-            arr: TreeNodeKey[],
-            children: InnerTreeOption[],
-            isAdd: boolean,
-        ) {
-            children &&
-                children.forEach((child) => {
-                    const index = arr.indexOf(child.value);
-                    if (!isAdd) {
-                        if (index !== -1) {
-                            arr.splice(index, 1);
-                        }
-                    } else if (index === -1) {
-                        arr.push(child.value);
-                    }
-                    if (child.children) {
-                        handleChildren(arr, child.children, isAdd);
-                    }
-                });
-        }
-        function handleParent(
-            arr: TreeNodeKey[],
-            indexPath: TreeNodeKey[],
-            isAdd: boolean,
-        ) {
-            let len = indexPath.length - 2;
-            for (len; len >= 0; len--) {
-                const parent = nodeList.get(indexPath[len]);
-                const index = arr.indexOf(parent.value);
-                if (!isAdd) {
-                    if (index !== -1) {
-                        arr.splice(index, 1);
-                    }
-                } else if (index === -1) {
-                    if (
-                        parent.children.every((item) =>
-                            arr.includes(item.value),
-                        )
-                    ) {
-                        arr.push(parent.value);
-                    }
-                }
-            }
-        }
-        const checkNode = (val: TreeNodeKey, event: Event) => {
-            const node = nodeList.get(val);
-            const { isLeaf, children, indexPath } = node;
-            const values = cloneDeep(currentCheckedKeys.value);
-            const index = values.indexOf(val);
-            if (!props.cascade) {
-                if (index !== -1) {
-                    values.splice(index, 1);
-                } else {
-                    values.push(val);
-                }
-            } else if (index !== -1) {
-                values.splice(index, 1);
-                handleParent(values, indexPath, false);
-                if (!isLeaf) {
-                    handleChildren(values, children, false);
-                }
-            } else {
-                values.push(val);
-                handleParent(values, indexPath, true);
-                if (!isLeaf) {
-                    handleChildren(values, children, true);
-                }
-            }
-            checkingNode = node;
-            updateCheckedKeys(values);
-            emit('check', {
-                checkedKeys: getCheckedKeys(values),
-                event,
-                node,
-                checked: values.includes(val),
-            });
-        };
 
         if (expose) {
             expose({

--- a/components/tree/useCheck.ts
+++ b/components/tree/useCheck.ts
@@ -49,6 +49,7 @@ export default ({
             if (props.checkStrictly === CHECK_STRATEGY.CHILD) {
                 return getParentByValues(nodeList, currentCheckedKeys.value);
             }
+            return currentCheckedKeys.value;
         }
         return [];
     }
@@ -187,11 +188,10 @@ export default ({
             }
             values = _values;
         } else {
-            if (props.checkStrictly === 'all') {
+            if (props.checkStrictly === CHECK_STRATEGY.ALL) {
                 computeCheckedKeys(_values, node);
                 values = _values;
-            }
-            if (props.checkStrictly === 'parent') {
+            } else if (props.checkStrictly === CHECK_STRATEGY.PARENT) {
                 computeCheckedKeys(_values, node);
                 values = _values.filter((key) => {
                     const node = nodeList.get(key);
@@ -202,13 +202,15 @@ export default ({
                         }).length === 1
                     );
                 });
-            }
-            if (props.checkStrictly === 'child') {
+            } else if (props.checkStrictly === CHECK_STRATEGY.CHILD) {
                 computeCheckedKeys(_values, node);
                 values = _values.filter((key) => {
                     const node = nodeList.get(key);
                     return node.isLeaf;
                 });
+            } else {
+                computeCheckedKeys(_values, node);
+                values = _values;
             }
         }
 
@@ -219,7 +221,7 @@ export default ({
             checkedKeys: values,
             event,
             node,
-            checked: values.includes(val),
+            checked: node.isChecked.value,
         });
     };
 

--- a/components/tree/useCheck.ts
+++ b/components/tree/useCheck.ts
@@ -1,0 +1,176 @@
+import { Ref, shallowRef, watch } from 'vue';
+import { cloneDeep } from 'lodash-es';
+import type { TreeNodeKey, InnerTreeOption } from './interface';
+import type { TreeProps } from './props';
+import { CHECK_STRATEGY } from './const';
+
+export default ({
+    allKeys,
+    nodeList,
+    currentCheckedKeys,
+    updateCheckedKeys,
+    props,
+    emit,
+}: {
+    allKeys: Ref<TreeNodeKey[]>;
+    nodeList: Map<TreeNodeKey, InnerTreeOption>;
+    currentCheckedKeys: Ref<TreeNodeKey[]>;
+    updateCheckedKeys: (keys: TreeNodeKey[]) => void;
+    props: TreeProps;
+    emit: any;
+}) => {
+    function getCheckedKeys(arr: TreeNodeKey[]) {
+        return props.cascade
+            ? arr.filter((key) => {
+                  const node = nodeList.get(key);
+                  if (props.checkStrictly === CHECK_STRATEGY.ALL) {
+                      return true;
+                  }
+                  if (props.checkStrictly === CHECK_STRATEGY.PARENT) {
+                      return (
+                          node.indexPath.filter((path) => arr.includes(path))
+                              .length === 1
+                      );
+                  }
+                  if (props.checkStrictly === CHECK_STRATEGY.CHILD) {
+                      return node.isLeaf;
+                  }
+                  return true;
+              })
+            : arr;
+    }
+
+    function handleChildren(
+        arr: TreeNodeKey[],
+        children: InnerTreeOption[],
+        isAdd: boolean,
+    ) {
+        children &&
+            children.forEach((child) => {
+                const index = arr.indexOf(child.value);
+                if (!isAdd) {
+                    if (index !== -1) {
+                        arr.splice(index, 1);
+                    }
+                } else if (index === -1) {
+                    arr.push(child.value);
+                }
+                if (child.children) {
+                    handleChildren(arr, child.children, isAdd);
+                }
+            });
+    }
+
+    function handleParent(
+        arr: TreeNodeKey[],
+        indexPath: TreeNodeKey[],
+        isAdd: boolean,
+    ) {
+        let len = indexPath.length - 2;
+        for (len; len >= 0; len--) {
+            const parent = nodeList.get(indexPath[len]);
+            const index = arr.indexOf(parent.value);
+            if (!isAdd) {
+                if (index !== -1) {
+                    arr.splice(index, 1);
+                }
+            } else if (index === -1) {
+                if (parent.children.every((item) => arr.includes(item.value))) {
+                    arr.push(parent.value);
+                }
+            }
+        }
+    }
+
+    function computeIndeterminate(key: TreeNodeKey) {
+        const node = nodeList.get(key);
+        if (node.hasChildren) {
+            if (node.isChecked.value) {
+                node.isIndeterminate.value = false;
+            } else {
+                node.isIndeterminate.value = node.children.some(
+                    (item) =>
+                        item.isChecked.value || item.isIndeterminate.value,
+                );
+            }
+        } else {
+            node.isIndeterminate.value = false;
+        }
+    }
+
+    const checkingNode: Ref<InnerTreeOption | null> = shallowRef(null);
+
+    watch(
+        currentCheckedKeys,
+        (newKeys, oldKeys) => {
+            // 重置历史节点选择状态
+            Array.isArray(oldKeys) &&
+                oldKeys.forEach((key: TreeNodeKey) => {
+                    const node = nodeList.get(key);
+                    node.isChecked.value = false;
+                });
+            newKeys.forEach((key: TreeNodeKey) => {
+                const node = nodeList.get(key);
+                node.isChecked.value = true;
+            });
+            if (props.cascade) {
+                // 当选中某个节点时，只需要处理此节点相关上下节点状态
+                if (checkingNode.value) {
+                    const node = checkingNode.value;
+                    const { indexPath } = node;
+                    indexPath.slice(0).reverse().forEach(computeIndeterminate);
+                    node.hasChildren &&
+                        node.childrenPath.forEach((key: TreeNodeKey) => {
+                            const node = nodeList.get(key);
+                            node.isIndeterminate.value = false;
+                        });
+                    checkingNode.value = null;
+                } else {
+                    allKeys.value.forEach(computeIndeterminate);
+                }
+            }
+        },
+        {
+            immediate: true,
+        },
+    );
+
+    const checkNode = (val: TreeNodeKey, event: Event) => {
+        const node = nodeList.get(val);
+        const { isLeaf, children, indexPath } = node;
+        const values = cloneDeep(currentCheckedKeys.value);
+        const index = values.indexOf(val);
+        if (!props.cascade) {
+            if (index !== -1) {
+                values.splice(index, 1);
+            } else {
+                values.push(val);
+            }
+        } else if (index !== -1) {
+            values.splice(index, 1);
+            handleParent(values, indexPath, false);
+            if (!isLeaf) {
+                handleChildren(values, children, false);
+            }
+        } else {
+            values.push(val);
+            handleParent(values, indexPath, true);
+            if (!isLeaf) {
+                handleChildren(values, children, true);
+            }
+        }
+        checkingNode.value = node;
+        updateCheckedKeys(values);
+        emit('check', {
+            checkedKeys: getCheckedKeys(values),
+            event,
+            node,
+            checked: values.includes(val),
+        });
+    };
+
+    return {
+        checkingNode,
+        checkNode,
+    };
+};

--- a/components/tree/useCurrentData.ts
+++ b/components/tree/useCurrentData.ts
@@ -1,0 +1,127 @@
+import { Ref, ref, watch } from 'vue';
+import { debounce } from 'lodash-es';
+import type { TreeNodeKey, InnerTreeOption } from './interface';
+import { concat } from '../_util/utils';
+
+export default ({
+    isSearchingRef,
+    filteredExpandedKeys,
+    currentExpandedKeys,
+    filteredKeys,
+    allKeys,
+    expandingNode,
+    nodeList,
+}: {
+    isSearchingRef: Ref<boolean>;
+    filteredExpandedKeys: Ref<TreeNodeKey[]>;
+    currentExpandedKeys: Ref<TreeNodeKey[]>;
+    filteredKeys: Ref<TreeNodeKey[]>;
+    allKeys: Ref<TreeNodeKey[]>;
+    expandingNode: Ref<InnerTreeOption | null>;
+    nodeList: Map<TreeNodeKey, InnerTreeOption>;
+}) => {
+    const currentData = ref<TreeNodeKey[]>([]);
+
+    const _addNode = (nodes: InnerTreeOption[], res: TreeNodeKey[] = []) => {
+        nodes.forEach((node) => {
+            res.push(node.value);
+            if (node.hasChildren && node.isExpanded.value) {
+                _addNode(node.children, res);
+            }
+        });
+    };
+
+    const addNode = (nodes: InnerTreeOption[], index: number) => {
+        const res: TreeNodeKey[] = [];
+        _addNode(nodes, res);
+        const arr1 = currentData.value.slice(0, index);
+        const arr2 = currentData.value.slice(index);
+        concat(arr1, res);
+        concat(arr1, arr2);
+        currentData.value = arr1;
+    };
+
+    const deleteNode = (keys: TreeNodeKey[], index: number) => {
+        let len = 0;
+        keys.forEach((key) => {
+            if (key === currentData.value[index + len]) {
+                len += 1;
+            }
+        });
+        currentData.value.splice(index, len);
+    };
+
+    const computeCurrentData = () => {
+        const res: TreeNodeKey[] = [];
+        const expandedKeys = isSearchingRef.value
+            ? filteredExpandedKeys.value
+            : currentExpandedKeys.value;
+
+        const keys = isSearchingRef.value ? filteredKeys.value : allKeys.value;
+
+        if (expandingNode.value) {
+            const node = expandingNode.value;
+            // 展开后
+            if (node.isExpanded.value) {
+                const index = currentData.value.indexOf(node.value);
+                addNode(node.children, index + 1);
+            } else {
+                const index = currentData.value.indexOf(node.value);
+                deleteNode(node.childrenPath, index + 1);
+            }
+            expandingNode.value = null;
+            return;
+        }
+
+        // 缓存每个节点的展开状态，性能更优
+        keys.forEach((key) => {
+            const node = nodeList.get(key);
+            if (node.hasChildren) {
+                node.isExpanded.value = expandedKeys.includes(key);
+            }
+            const indexPath = node.indexPath;
+            const len = indexPath.length;
+            let index = 0;
+            let parentExpanded = true;
+            while (index < len - 1) {
+                const parentNode = nodeList.get(indexPath[index]);
+                if (!parentNode.isExpanded.value) {
+                    parentExpanded = false;
+                    break;
+                }
+                index += 1;
+            }
+            if (parentExpanded) {
+                res.push(key);
+            }
+        });
+        currentData.value = res;
+    };
+
+    watch(
+        [filteredExpandedKeys, filteredKeys],
+        debounce(() => {
+            if (!isSearchingRef.value) return;
+            computeCurrentData();
+        }, 10),
+    );
+
+    watch(
+        [currentExpandedKeys, allKeys],
+        debounce(() => {
+            if (isSearchingRef.value) return;
+            computeCurrentData();
+        }, 10),
+        {
+            immediate: true,
+        },
+    );
+
+    watch([isSearchingRef], () => {
+        computeCurrentData();
+    });
+
+    return {
+        currentData,
+    };
+};

--- a/components/tree/useData.ts
+++ b/components/tree/useData.ts
@@ -9,10 +9,20 @@ const getUid = () => {
     return uid++;
 };
 
-export default ({ props }: { props: TreeProps }) => {
+export default ({ props, emit }: { props: TreeProps; emit: any }) => {
     const nodeList: Map<TreeNodeKey, InnerTreeOption> = new Map();
 
-    const transformData = ref<TreeNodeKey[]>([]);
+    const allKeys = ref<TreeNodeKey[]>([]);
+
+    watch(
+        allKeys,
+        () => {
+            emit('update:nodeList', nodeList);
+        },
+        {
+            immediate: true,
+        },
+    );
 
     const transformNode = (
         item: InnerTreeOption,
@@ -94,7 +104,7 @@ export default ({ props }: { props: TreeProps }) => {
     watch(
         [() => props.data],
         () => {
-            transformData.value = flatNodes(props.data);
+            allKeys.value = flatNodes(props.data);
         },
         {
             immediate: true,
@@ -104,6 +114,6 @@ export default ({ props }: { props: TreeProps }) => {
 
     return {
         nodeList,
-        transformData,
+        allKeys,
     };
 };

--- a/components/tree/useExpand.ts
+++ b/components/tree/useExpand.ts
@@ -1,0 +1,78 @@
+import { Ref, shallowRef, onMounted } from 'vue';
+import { cloneDeep } from 'lodash-es';
+import type { TreeNodeKey, InnerTreeOption } from './interface';
+import type { TreeProps } from './props';
+
+export default ({
+    isSearchingRef,
+    filteredExpandedKeys,
+    nodeList,
+    currentExpandedKeys,
+    updateExpandedKeys,
+    props,
+    emit,
+    allKeys,
+}: {
+    isSearchingRef: Ref<boolean>;
+    filteredExpandedKeys: Ref<TreeNodeKey[]>;
+    nodeList: Map<TreeNodeKey, InnerTreeOption>;
+    currentExpandedKeys: Ref<TreeNodeKey[]>;
+    updateExpandedKeys: (keys: TreeNodeKey[]) => void;
+    props: TreeProps;
+    emit: any;
+    allKeys: Ref<TreeNodeKey[]>;
+}) => {
+    const expandingNode: Ref<InnerTreeOption | null> = shallowRef(null);
+
+    const expandNode = (val: TreeNodeKey, event: Event) => {
+        if (isSearchingRef.value) {
+            const _value = cloneDeep(filteredExpandedKeys.value);
+            const index = _value.indexOf(val);
+            // 已经展开
+            if (index !== -1) {
+                _value.splice(index, 1);
+            } else {
+                _value.push(val);
+            }
+            filteredExpandedKeys.value = _value;
+            return;
+        }
+        const node = nodeList.get(val);
+        expandingNode.value = node;
+        let values: TreeNodeKey[] = cloneDeep(currentExpandedKeys.value);
+        const index = values.indexOf(val);
+        // 已经展开
+        if (index !== -1) {
+            values.splice(index, 1);
+            // 让动画早点动起来
+            node.isExpanded.value = false;
+        } else {
+            if (props.accordion) {
+                values = values.filter((item) => node.indexPath.includes(item));
+            }
+            values.push(val);
+            // 让动画早点动起来
+            node.isExpanded.value = true;
+        }
+        updateExpandedKeys(values);
+        emit('expand', {
+            expandedKeys: values,
+            event,
+            node,
+            expanded: values.includes(val),
+        });
+    };
+
+    onMounted(() => {
+        if (props.defaultExpandAll && currentExpandedKeys.value.length === 0) {
+            updateExpandedKeys(
+                allKeys.value.filter((value) => !nodeList.get(value).isLeaf),
+            );
+        }
+    });
+
+    return {
+        expandNode,
+        expandingNode,
+    };
+};

--- a/components/tree/useFilter.ts
+++ b/components/tree/useFilter.ts
@@ -6,12 +6,12 @@ import type { TreeProps } from './props';
 
 export default (
     props: TreeProps,
-    transformData: Ref<TreeNodeKey[]>,
+    allKeys: Ref<TreeNodeKey[]>,
     nodeList: Map<TreeNodeKey, InnerTreeOption>,
 ) => {
     const filteredKeys = ref<TreeNodeKey[]>([]);
     const filteredExpandedKeys = ref<TreeNodeKey[]>([]);
-    const isSearchingRef = ref(false);
+    const isSearchingRef = ref<boolean>(false);
 
     function traverse(
         filterMethod: (filterText: string, node: InnerTreeOption) => boolean,
@@ -21,7 +21,7 @@ export default (
         const _filteredKeys: TreeNodeKey[] = [];
         const _filteredExpandedKeysMap = new Map<TreeNodeKey, boolean>();
         const _filteredKeysMap = new Map<TreeNodeKey, boolean>();
-        transformData.value.forEach((key) => {
+        allKeys.value.forEach((key) => {
             const node: InnerTreeOption = nodeList.get(key);
             if (filterMethod(filterText, node)) {
                 const parentKeys = node.indexPath;

--- a/components/tree/useSelect.ts
+++ b/components/tree/useSelect.ts
@@ -1,0 +1,49 @@
+import { Ref } from 'vue';
+import { cloneDeep } from 'lodash-es';
+import type { TreeNodeKey, InnerTreeOption } from './interface';
+import type { TreeProps } from './props';
+
+export default ({
+    nodeList,
+    currentSelectedKeys,
+    updateSelectedKeys,
+    props,
+    emit,
+}: {
+    nodeList: Map<TreeNodeKey, InnerTreeOption>;
+    currentSelectedKeys: Ref<TreeNodeKey[]>;
+    updateSelectedKeys: (keys: TreeNodeKey[]) => void;
+    props: TreeProps;
+    emit: any;
+}) => {
+    const selectNode = (val: TreeNodeKey, event: Event) => {
+        if (!props.selectable) {
+            return;
+        }
+        const node = nodeList.get(val);
+        const values = cloneDeep(currentSelectedKeys.value);
+        const index = values.indexOf(val);
+        if (props.multiple) {
+            if (index !== -1) {
+                props.cancelable && values.splice(index, 1);
+            } else {
+                values.push(val);
+            }
+        } else if (index !== -1) {
+            props.cancelable && values.splice(index, 1);
+        } else {
+            values[0] = val;
+        }
+        updateSelectedKeys(values);
+        emit('select', {
+            selectedKeys: values,
+            event,
+            node,
+            selected: values.includes(val),
+        });
+    };
+
+    return {
+        selectNode,
+    };
+};

--- a/components/tree/useState.ts
+++ b/components/tree/useState.ts
@@ -3,7 +3,7 @@ import { useNormalModel } from '../_util/use/useModel';
 import type { TreeNodeKey } from './interface';
 import type { TreeProps } from './props';
 
-export default (props: TreeProps, { emit }: { emit: any }) => {
+export default ({ props, emit }: { props: TreeProps; emit: any }) => {
     const [currentExpandedKeys, updateExpandedKeys] = useNormalModel(
         props,
         emit,

--- a/docs/.vitepress/components/tree/index.md
+++ b/docs/.vitepress/components/tree/index.md
@@ -91,7 +91,7 @@ app.use(FTree);
 | cancelable                | 选中后是否可以再次点击取消选中                                                   | boolean                                   | `true`    |
 | checkable             | 是否显示 `Checkbox` 选择框                                            | boolean                                   | `false`    |
 | cascade             | 当勾选选择框时，父子节点的选择框勾选状态是否关联，相互影响                                           | boolean                                   | `false`    |
-| checkStrictly         | 设置勾选策略来计算`check`事件中`checkedKeys`，`all`为全部选中节点；`parent` 为全部选中节点中的父节点（当父节点下所有子节点都选中时）；`child` 为全部选中节点中的叶子节点          | string                                   | `all`    |
+| checkStrictly         | 设置勾选策略来计算`checkedKeys`，`all`为全部选中节点；`parent` 为全部选中节点中的父节点（当父节点下所有子节点都选中时）；`child` 为全部选中节点中的叶子节点          | string                                   | `all`    |
 | checkedKeys(v-model)  | 勾选节点 key 的数组                                                 | Array<string \| number>                   | `[]`       |
 | childrenField         | 替代 `TreeOption` 中的 `children` 字段名                                | string                                    | `children` |
 | valueField            | 替代 `TreeOption` 中的 `value` 字段名                                   | string                                    | `value`    |

--- a/docs/.vitepress/components/tree/virtualList.vue
+++ b/docs/.vitepress/components/tree/virtualList.vue
@@ -1,13 +1,20 @@
 <template>
-    <FTree :data="data" virtualList checkable cascade></FTree>
+    <FTree
+        v-model:checkedKeys="checkedKeys"
+        :data="data"
+        virtualList
+        checkable
+        cascade
+        checkStrictly="parent"
+    ></FTree>
 </template>
 <script>
-import { reactive } from 'vue';
+import { reactive, ref } from 'vue';
 
 function createData(level = 4, baseKey = '') {
     if (!level) return undefined;
     return Array.apply(null, { length: 15 - level }).map((_, index) => {
-        const key = `${baseKey}_${index}`;
+        const key = baseKey ? `${baseKey}_${index}` : `${index}`;
         return {
             label: createLabel(level, index),
             value: key,
@@ -26,8 +33,10 @@ function createLabel(level, index) {
 export default {
     setup() {
         const data = reactive(createData());
+        const checkedKeys = ref(['0']);
         return {
             data,
+            checkedKeys,
         };
     },
 };

--- a/docs/.vitepress/components/tree/virtualList.vue
+++ b/docs/.vitepress/components/tree/virtualList.vue
@@ -13,7 +13,7 @@ import { reactive, ref } from 'vue';
 
 function createData(level = 4, baseKey = '') {
     if (!level) return undefined;
-    return Array.apply(null, { length: 15 - level }).map((_, index) => {
+    return Array.apply(null, { length: 10 }).map((_, index) => {
         const key = baseKey ? `${baseKey}_${index}` : `${index}`;
         return {
             label: createLabel(level, index),


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

-   [x] Bugfix
-   [x] Feature
-   [ ] Code style update
-   [ ] Refactor
-   [ ] Docs
-   [ ] Build-related changes
-   [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

-   [x] Yes
-   [ ] No

If yes, please describe the impact and migration path for existing applications:

`checkStrictly` 不仅影响 check 事件中的 checkedKeys 而且影响属性`checkedKeys`的逻辑，传入的 checkedKeys 需适配 `checkStrictly`。所以当组件配置了`checkStrictly`，且`checkStrictly`不为 `all`时，需要注意：
1. `checkedKeys`默认值需做响应适配
2. 勾选节点后`checkedKeys`的值也会跟上个版本不一样。

**Related issue (if exists):**

**Other information:**
