### PR TITLE
fix: 修复change事件中更新v-model值无效问题

### DIFF
--- a/components/_util/use/useSelect.ts
+++ b/components/_util/use/useSelect.ts
@@ -1,4 +1,4 @@
-import { inject, ref, computed } from 'vue';
+import { inject, ref, computed, nextTick } from 'vue';
 import { CHANGE_EVENT } from '../constants';
 import { useNormalModel } from './useModel';
 import useFormAdaptor from './useFormAdaptor';
@@ -49,7 +49,9 @@ export default ({
         } else {
             const newVal = !currentValue.value;
             updateCurrentValue(newVal);
-            emit(CHANGE_EVENT, newVal);
+            nextTick(() => {
+                emit(CHANGE_EVENT, newVal);
+            });
             validate(CHANGE_EVENT);
         }
     };

--- a/components/carousel/carousel.tsx
+++ b/components/carousel/carousel.tsx
@@ -1,9 +1,9 @@
 import { defineComponent, watch, ref, PropType, ExtractPropTypes } from 'vue';
+import { useTheme } from '../_theme/useTheme';
+import useResize from '../_util/use/useResize';
 import { CAROUSEL_NAME, CHANGE_EVENT } from './const';
 import Arrow from './arrow';
 import Indicator from './indicator';
-import { useTheme } from '../_theme/useTheme';
-import useResize from '../_util/use/useResize';
 
 import useCarousel from './useCarousel';
 import useCarouselStyle from './useCarouselStyle';

--- a/components/checkbox-group/useCheckboxGroup.ts
+++ b/components/checkbox-group/useCheckboxGroup.ts
@@ -1,4 +1,4 @@
-import { provide, unref } from 'vue';
+import { provide, unref, nextTick } from 'vue';
 import { useArrayModel } from '../_util/use/useModel';
 import useFormAdaptor from '../_util/use/useFormAdaptor';
 import { CHANGE_EVENT } from '../_util/constants';
@@ -18,7 +18,9 @@ export const useCheckboxGroup = (
     const [currentValue, updateItem] = useArrayModel(props, emit);
 
     const handleChange = () => {
-        emit(CHANGE_EVENT, currentValue.value);
+        nextTick(() => {
+            emit(CHANGE_EVENT, currentValue.value);
+        });
         validate(CHANGE_EVENT);
     };
 

--- a/components/collapse/collapse.vue
+++ b/components/collapse/collapse.vue
@@ -6,11 +6,11 @@
 
 <script lang="ts">
 import { provide, defineComponent, computed } from 'vue';
+import { useTheme } from '../_theme/useTheme';
+import { useNormalModel } from '../_util/use/useModel';
 import { collapseEmits, collapseProps } from './collapseExpose';
 import { useNamespace } from './useNamespace';
 import { arrowPositionKey, collapseContextKey } from './common';
-import { useTheme } from '../_theme/useTheme';
-import { useNormalModel } from '../_util/use/useModel';
 import type { CollapseActiveName } from './common';
 
 export default defineComponent({

--- a/components/date-picker/datePicker.vue
+++ b/components/date-picker/datePicker.vue
@@ -98,6 +98,7 @@ import {
     ExtractPropTypes,
     ComputedRef,
     ComponentPublicInstance,
+    nextTick,
 } from 'vue';
 import { format, isValid } from 'date-fns';
 import { isEqual, isNil, isArray } from 'lodash-es';
@@ -340,7 +341,9 @@ export default defineComponent({
         const handleChange = (val: number | number[] | null) => {
             if (!isEqual(val, currentValue.value)) {
                 updateCurrentValue(val);
-                emit('change', val);
+                nextTick(() => {
+                    emit('change', val);
+                });
                 validate('change');
             }
         };

--- a/components/input-number/input-number.vue
+++ b/components/input-number/input-number.vue
@@ -166,7 +166,9 @@ export default defineComponent({
             tempValue.value = null;
             updateCurrentValue(newVal);
             emit('input', newVal);
-            emit('change', newVal, oldVal);
+            nextTick(() => {
+                emit('change', newVal, oldVal);
+            });
             validate('input');
             validate('change');
         };

--- a/components/radio-group/useRadioGroup.ts
+++ b/components/radio-group/useRadioGroup.ts
@@ -1,4 +1,4 @@
-import { provide, unref } from 'vue';
+import { provide, unref, nextTick } from 'vue';
 import { useNormalModel } from '../_util/use/useModel';
 import { CHANGE_EVENT } from '../_util/constants';
 import useFormAdaptor from '../_util/use/useFormAdaptor';
@@ -16,7 +16,9 @@ export const useRadioGroup = (
     const [currentValue, updateCurrentValue] = useNormalModel(props, emit);
 
     const handleChange = () => {
-        emit(CHANGE_EVENT, currentValue.value);
+        nextTick(() => {
+            emit(CHANGE_EVENT, currentValue.value);
+        });
         validate(CHANGE_EVENT);
     };
 

--- a/components/select-tree/selectTree.vue
+++ b/components/select-tree/selectTree.vue
@@ -127,6 +127,7 @@ import {
     onMounted,
     CSSProperties,
     PropType,
+    nextTick,
 } from 'vue';
 import { debounce } from 'lodash-es';
 import getPrefixCls from '../_util/getPrefixCls';
@@ -204,7 +205,9 @@ export default defineComponent({
         });
 
         const handleChange = () => {
-            emit(CHANGE_EVENT, currentValue.value);
+            nextTick(() => {
+                emit(CHANGE_EVENT, currentValue.value);
+            });
             validate(CHANGE_EVENT);
         };
 

--- a/components/select/select.vue
+++ b/components/select/select.vue
@@ -78,6 +78,7 @@ import {
     onMounted,
     CSSProperties,
     defineComponent,
+    nextTick,
 } from 'vue';
 import { isNil } from 'lodash-es';
 import getPrefixCls from '../_util/getPrefixCls';
@@ -143,7 +144,9 @@ export default defineComponent({
         });
 
         const handleChange = () => {
-            emit(CHANGE_EVENT, unref(currentValue));
+            nextTick(() => {
+                emit(CHANGE_EVENT, unref(currentValue));
+            });
             validate(CHANGE_EVENT);
         };
 

--- a/components/switch/switch.vue
+++ b/components/switch/switch.vue
@@ -85,7 +85,9 @@ export default defineComponent({
         const loadingRef = ref(false);
 
         const handleChange = () => {
-            ctx.emit(CHANGE_EVENT, currentValue.value);
+            nextTick(() => {
+                ctx.emit(CHANGE_EVENT, currentValue.value);
+            });
             validate(CHANGE_EVENT);
         };
 

--- a/components/time-picker/time-picker.vue
+++ b/components/time-picker/time-picker.vue
@@ -80,20 +80,21 @@ import {
     computed,
     PropType,
     ExtractPropTypes,
+    nextTick,
 } from 'vue';
 import { UPDATE_MODEL_EVENT } from '../_util/constants';
 import useFormAdaptor from '../_util/use/useFormAdaptor';
 import getPrefixCls from '../_util/getPrefixCls';
 import { useNormalModel } from '../_util/use/useModel';
 import { useTheme } from '../_theme/useTheme';
-import TimeSelect from './time-select.vue';
 import InputInner from '../input/inputInner.vue';
 import { ClockCircleOutlined } from '../icon';
 import Popper from '../popper';
 import FButton from '../button';
 
-import type { GetContainer } from '../_util/interface';
 import { useLocale } from '../config-provider/useLocale';
+import TimeSelect from './time-select.vue';
+import type { GetContainer } from '../_util/interface';
 
 const prefixCls = getPrefixCls('time-picker');
 
@@ -275,7 +276,9 @@ export default defineComponent({
             if (val !== currentValue.value) {
                 tempValue.value = '';
                 updateCurrentValue(val);
-                emit('change', val);
+                nextTick(() => {
+                    emit('change', val);
+                });
                 validate('change');
                 activeTime.value = val;
             }

--- a/docs/.vitepress/components/checkbox/common.vue
+++ b/docs/.vitepress/components/checkbox/common.vue
@@ -1,7 +1,22 @@
 <template>
     <FSpace>
-        <FCheckbox>复选框</FCheckbox>
+        <FCheckbox v-model="checked" @change="handleChange">复选框</FCheckbox>
         <FCheckbox disabled>复选框-禁用状态</FCheckbox>
         <FCheckbox indeterminate>复选框-不确定状态</FCheckbox>
     </FSpace>
 </template>
+<script>
+import { ref } from 'vue';
+export default {
+    setup() {
+        const checked = ref();
+        const handleChange = (val) => {
+            console.log(val);
+        };
+        return {
+            checked,
+            handleChange,
+        };
+    },
+};
+</script>


### PR DESCRIPTION
在组件中执行updateCurrentValue，同时会抛出change事件。如果在change事件中更新v-model的绑定的值，可能导致组件内的currentValue改变，但是组件外的v-model在change中修改的跟上次没差异，导致不会触发watch(()=> props.modelValue)，出现组件内部状态和外部v-model值不一致。

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update
-   [ ] Refactor
-   [ ] Docs
-   [ ] Build-related changes
-   [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

-   [ ] Yes
-   [x] No

If yes, please describe the impact and migration path for existing applications:

**Related issue (if exists):**

**Other information:**
