### PR TITLE
fix: FDatePicker组件月份范围选择异常

### DIFF
--- a/components/date-picker/pickerHandler.ts
+++ b/components/date-picker/pickerHandler.ts
@@ -141,13 +141,7 @@ export class DateMonthRangePicker implements Picker {
         return leftDate.year === rightDate.year;
     }
     getRangeSelectedDate(date: Partial<DateObj>, preDate: DateObj) {
-        return Object.assign(
-            date,
-            {
-                day: preDate.day,
-            },
-            pickTime(preDate),
-        ) as DateObj;
+        return Object.assign(date, pickTime(preDate)) as DateObj;
     }
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

-   [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

-   [ ] Yes
-   [x] No

If yes, please describe the impact and migration path for existing applications:

**Related issue (if exists):*https://github.com/WeBankFinTech/fes-design/issues/547*

**Other information:**
  造成的原因是选择范围的第二个数的天数day会被第一个数覆盖，如果第一个数的day是31，在第二个数是小月的情况下没有31天就会往前进一个月
