### PR TITLE
feat: include documents in npm package for ai agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/zh/components
 
 tsconfig.tsbuildinfo
 types
+doc

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "es",
     "icon",
     "scripts",
-    "types"
+    "types",
+    "doc"
   ],
   "scripts": {
     "prepare": "husky install",
@@ -55,7 +56,8 @@
     "build:style": "node scripts/build-style.js",
     "build:type": "node scripts/build-types.js",
     "build:icon": "node scripts/build-icon.js",
-    "build": "npm run build:version && npm run build:esm && npm run build:type && cp -rf es/icon . && npm run build:esm-browser && npm run build:umd && npm run build:style && npm run build:icon",
+    "build:in-bundle-doc": "docs:build && node script/copyDocs.js",
+    "build": "build:in-bundle-doc && npm run build:version && npm run build:esm && npm run build:type && cp -rf es/icon . && npm run build:esm-browser && npm run build:umd && npm run build:style && npm run build:icon",
     "release": "node scripts/release.js",
     "lint-staged": "lint-staged --allow-empty",
     "commitlint": "commitlint --config commitlint.config.cjs -e -V",

--- a/scripts/copyDocs.cjs
+++ b/scripts/copyDocs.cjs
@@ -1,0 +1,46 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SRC_DIR = path.resolve(__dirname, '../docs/.vitepress/dist');
+const DEST_DIR = path.resolve(__dirname, '../doc');
+
+function collectMdFiles(dir, base = '') {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const relPath = base ? `${base}/${entry.name}` : entry.name;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...collectMdFiles(fullPath, relPath));
+        } else if (entry.name.endsWith('.md')) {
+            files.push({ relPath, fullPath, name: entry.name.replace('.md', '') });
+        }
+    }
+    return files;
+}
+
+if (!fs.existsSync(SRC_DIR)) {
+    console.error(`Source directory not found: ${SRC_DIR}`);
+    console.error('Please run "npm run docs:build" first.');
+    // eslint-disable-next-line node/prefer-global/process
+    process.exit(1);
+}
+
+fs.rmSync(DEST_DIR, { recursive: true, force: true });
+fs.mkdirSync(DEST_DIR, { recursive: true });
+
+const files = collectMdFiles(SRC_DIR);
+
+const indexLines = ['# Document Index', ''];
+
+for (const file of files) {
+    const destSubDir = path.join(DEST_DIR, path.dirname(file.relPath));
+    fs.mkdirSync(destSubDir, { recursive: true });
+    fs.copyFileSync(file.fullPath, path.join(DEST_DIR, file.relPath));
+    indexLines.push(`- [${file.name}](${file.relPath})`);
+}
+
+fs.writeFileSync(path.join(DEST_DIR, 'index.md'), `${indexLines.join('\n')}\n`);
+
+console.log(`Copied ${files.length} .md files to ${DEST_DIR}`);
+console.log(`Generated index.md with ${files.length} entries`);


### PR DESCRIPTION
copy .md from vitepress's output to `./doc` and include them in npm package.
<img width="206" height="153" alt="image" src="https://github.com/user-attachments/assets/e5b577fa-4658-4fc4-81e1-c05f5cb4e7e6" />
inspired by next.
<img width="771" height="455" alt="image" src="https://github.com/user-attachments/assets/d3e9adc9-3e70-418c-b6b6-3040733cd8cd" />
**What kind of change does this PR introduce?** (check at least one)

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update
-   [ ] Refactor
-   [ ] Docs
-   [ ] Build-related changes
-   [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

-   [ ] Yes
-   [x] No

If yes, please describe the impact and migration path for existing applications:

**Related issue (if exists):**

**Other information:**
