### PR TITLE
fix: table multiple=false 时单选框勾选状态不显示

### DIFF
--- a/components/table/useTableSelect.ts
+++ b/components/table/useTableSelect.ts
@@ -178,7 +178,7 @@ export default ({
     };
 
     const clearSelect = () => {
-        currentCheckedKeys.value.length = 0;
+        currentCheckedKeys.value = [];
     };
 
     // 模式变更，单选只能有一个被选择


### PR DESCRIPTION
## 修复内容

**问题**：Table 组件在 `multiple=false` 时，单选框不会显示勾选状态。

**根因**：`useTableSelect.ts` 中 `clearSelect()` 函数使用 `.length = 0` 直接修改数组，绕过了 Vue 响应式系统。

**修复**：改为赋值空数组 `currentCheckedKeys.value = []` 触发响应式更新。

**文件**：`components/table/useTableSelect.ts`

---

## 测试

- [x] 本地验证修复后单选框勾选状态正确显示