### PR TITLE
fix: 修复表格 span 不生效问题 (#958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Bug Fixes
 
+* form inline span grid-column CSS syntax fix - use `grid-column: span @value` instead of broken `span @{value} / span @{value}` pattern ([#958](https://github.com/WeBankFinTech/fes-design/issues/958))
 * table multiple=false 时单选框勾选状态不显示 ([#961](https://github.com/WeBankFinTech/fes-design/issues/961)) ([46d6f24](https://github.com/WeBankFinTech/fes-design/commit/46d6f24c9dab2d3d41ffe028969a5be64ea1965c))
 * vite8 css 变量处理问题 ([#963](https://github.com/WeBankFinTech/fes-design/issues/963)) ([df12c80](https://github.com/WeBankFinTech/fes-design/commit/df12c800130920d9cc1991677fc3a05d6b625037))
 

--- a/components/form/__tests__/form-span.spec.ts
+++ b/components/form/__tests__/form-span.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const FORM_PATH = path.resolve(__dirname, '../style/index.less');
+
+describe('form span grid-column fix', () => {
+    it('LESS file includes grid-column: span @value pattern (fixed), not broken span @{value} / span @{value} pattern', () => {
+        const content = fs.readFileSync(FORM_PATH, 'utf-8');
+        expect(content).toContain('grid-column: span @value');
+        expect(content).not.toContain('span @{value} / span @{value}');
+    });
+
+    it('FForm inline layout generates f-form-item-span-N classes via each loop', () => {
+        const content = fs.readFileSync(FORM_PATH, 'utf-8');
+        const hasEachLoop = content.includes('each(range(24),') || content.includes('each(range(24), {');
+        expect(hasEachLoop).toBe(true);
+        expect(content).toContain('.@{form-item-cls}-span-@{value}');
+        expect(content).toContain('grid-column: span @value');
+    });
+});

--- a/components/form/style/index.less
+++ b/components/form/style/index.less
@@ -101,7 +101,7 @@
     // formItem 的 span 属性，占据的列数
     each(range(24), {
         .@{form-item-cls}-span-@{value} {
-            grid-column: span @value / span @value;
+            grid-column: span @value;
         }
     });
 }

--- a/e2e/form-span.spec.ts
+++ b/e2e/form-span.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test.describe('Form inline layout span', () => {
+    test('inline form renders f-form-item-span-12 class on each item when span=12', async ({ page }) => {
+        await page.goto('/components/form/index.html');
+
+        const inlineForm = page.locator('.f-form-inline');
+        await expect(inlineForm).toBeVisible({ timeout: 10000 });
+
+        const span12Items = page.locator('.f-form-item-span-12');
+        const count = await span12Items.count();
+        expect(count).toBeGreaterThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
## Summary
- 修复在 `layout="inline"` 时，设置 `:span="12"` 等属性不生效的问题
- 修复原因：LESS 中 `grid-column: span @value / span @value;` 是无效语法，改为 `grid-column: span @value;`