### PR TITLE
fix(step): 兼容 title/description 空值样式 (#882)

### DIFF
--- a/components/steps/__tests__/step-882.spec.ts
+++ b/components/steps/__tests__/step-882.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { h } from 'vue';
+import FSteps from '../steps';
+import FStep from '../step';
+
+describe('Step issue #882 - empty title/description', () => {
+    const mountComponent = (props = {}, stepSlots = {}) => {
+        return mount(FSteps, {
+            slots: {
+                default: () => [
+                    h(FStep, { ...props, ...stepSlots }),
+                ],
+            },
+        });
+    };
+
+    it('should NOT render .fes-step-title when title is empty string', () => {
+        const wrapper = mountComponent({ title: '' });
+        const titleEl = wrapper.findAll('.fes-step-title');
+        expect(titleEl.length).toBe(0);
+    });
+
+    it('should NOT render .fes-step-title when title is undefined', () => {
+        const wrapper = mountComponent({});
+        const titleEl = wrapper.findAll('.fes-step-title');
+        expect(titleEl.length).toBe(0);
+    });
+
+    it('should render .fes-step-title with correct text when title is provided', () => {
+        const wrapper = mountComponent({ title: 'Step 1' });
+        const titleEl = wrapper.find('.fes-step-title');
+        expect(titleEl.exists()).toBe(true);
+        expect(titleEl.text()).toBe('Step 1');
+    });
+
+    it('should NOT render .fes-step-title or .fes-step-description when both are empty', () => {
+        const wrapper = mountComponent({ title: '', description: '' });
+        const titleEl = wrapper.findAll('.fes-step-title');
+        const descEl = wrapper.findAll('.fes-step-description');
+        expect(titleEl.length).toBe(0);
+        expect(descEl.length).toBe(0);
+    });
+});

--- a/components/steps/step.tsx
+++ b/components/steps/step.tsx
@@ -158,18 +158,21 @@ export default defineComponent({
             <div ref={itemDomRef} class={classList.value} style={style.value}>
                 {renderSymbol()}
                 <div class={`${prefixCls}-content`}>
-                    <div class={`${prefixCls}-title`}>
-                        <span class={`${prefixCls}-text`} onClick={onClickStep}>
-                            {slots.title?.() || `${props.title}`}
-                        </span>
-                        {!parent.props.vertical && (
-                            <div class={`${prefixCls}-tail`}></div>
-                        )}
-                    </div>
-                    <div class={`${prefixCls}-description`}>
-                        {(slots.description || props.description)
-                        && (slots.description?.() || props.description)}
-                    </div>
+                    {(slots.title || props.title) && (
+                        <div class={`${prefixCls}-title`}>
+                            <span class={`${prefixCls}-text`} onClick={onClickStep}>
+                                {slots.title?.() ?? props.title}
+                            </span>
+                            {!parent.props.vertical && (
+                                <div class={`${prefixCls}-tail`}></div>
+                            )}
+                        </div>
+                    )}
+                    {(slots.description || props.description) && (
+                        <div class={`${prefixCls}-description`}>
+                            {slots.description?.() ?? props.description}
+                        </div>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
## 修复内容

Step 组件当 `title` 或 `description` 为空字符串/undefined 时，**空 div 仍会渲染**（带着 margin/padding），造成标题区有偏移的视觉问题。

**根因**（`components/steps/step.tsx` 渲染函数）：
- title 用 `{slots.title?.() || `${props.title}`}` —— undefined 被 stringified 成 "undefined"，empty 字符串也通过 `||` fallback
- description 的 wrapper div 没有 `&&` 守卫，只对内容有
- `<div class="...-title">` 和 `<div class="...-description">` 始终渲染

**修复**：
- title div 整块用 `(slots.title || props.title) &&` 守卫，有内容才渲染
- description div 同样加守卫
- `${props.title}` → `props.title ??`（避免 undefined 被渲染为字面 "undefined"）

## 验证

```bash
PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH" ./node_modules/.bin/vitest run components/steps
```

- 4/4 tests passed
- 测试覆盖：title="" / title=undefined / title="Step 1" / title+description 都空

## 改动文件

- `components/steps/step.tsx` — 渲染函数加守卫
- `components/steps/__tests__/step-882.spec.ts` — 4 个 vitest 单测

无 lockfile 污染，无 test infra 修改。

Closes #882