### PR TITLE
feat(button): 增加 circle 配置项 (#733)

### DIFF
--- a/components/button/__tests__/button-733.spec.ts
+++ b/components/button/__tests__/button-733.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FButton from '../button';
+
+describe('FButton circle prop (#733)', () => {
+    it('circle prop not passed → fes-btn-circle class NOT present', () => {
+        const wrapper = mount(FButton, {
+            props: {},
+            slots: { default: 'Button' },
+        });
+        expect(wrapper.classes()).not.toContain('fes-btn-circle');
+    });
+
+    it('circle true → fes-btn-circle class IS present', () => {
+        const wrapper = mount(FButton, {
+            props: { circle: true },
+            slots: { default: 'Button' },
+        });
+        expect(wrapper.classes()).toContain('fes-btn-circle');
+    });
+
+    it('circle true with type=primary → both fes-btn-type-primary and fes-btn-circle present', () => {
+        const wrapper = mount(FButton, {
+            props: { circle: true, type: 'primary' },
+            slots: { default: 'Button' },
+        });
+        expect(wrapper.classes()).toContain('fes-btn-type-primary');
+        expect(wrapper.classes()).toContain('fes-btn-circle');
+    });
+
+    it('circle true with size=small → both fes-btn-small and fes-btn-circle present', () => {
+        const wrapper = mount(FButton, {
+            props: { circle: true, size: 'small' },
+            slots: { default: 'Button' },
+        });
+        expect(wrapper.classes()).toContain('fes-btn-small');
+        expect(wrapper.classes()).toContain('fes-btn-circle');
+    });
+});

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -52,6 +52,10 @@ export const buttonProps = {
         type: String as PropType<'left' | 'right'>,
         default: 'left',
     },
+    circle: {
+        type: Boolean,
+        default: false,
+    },
 } as const satisfies ComponentObjectPropsOptions;
 
 export type ButtonProps = ExtractPublicPropTypes<typeof buttonProps>;
@@ -101,6 +105,7 @@ export default defineComponent({
             props.long && `${prefixCls}-long`,
             props.size !== 'middle' && `${prefixCls}-${props.size}`,
             props.loading && 'is-loading',
+            props.circle && `${prefixCls}-circle`,
         ]);
 
         return () => (

--- a/components/button/style/index.less
+++ b/components/button/style/index.less
@@ -254,10 +254,19 @@
         --f-btn-height: @btn-height-lg;
         --f-btn-font-size: calc(var(--f-font-size-base) + 2px);
     }
-    &-small {
+        &-small {
         --f-btn-min-width: @btn-min-width-sm;
         --f-btn-height: @btn-height-sm;
         --f-btn-padding: @btn-padding-sm;
+        --f-btn-font-size: calc(var(--f-font-size-base) - 2px);
+        --f-btn-border-radius: var(--f-btn-border-radius-sm);
+    }
+
+    &-circle {
+        border-radius: 50%;
+        padding: 0;
+    }
+}
         --f-btn-font-size: calc(var(--f-font-size-base) - 2px);
         --f-btn-border-radius: var(--f-btn-border-radius-sm);
     }


### PR DESCRIPTION
## 修复内容

FButton 加 `circle` 配置项 —— 圆形 icon-only 按钮，与 primary/default/warning/danger 等 type 兼容。

## 改动

- `button.tsx` —— 加 `circle: Boolean` prop (default false)，classList 拼接 `fes-btn-circle`
- `style/index.less` —— 加 `.fes-btn-circle { border-radius: 50%; padding: 0; }`
- `button-733.spec.ts` —— 4 个行为测试

## 验证

```bash
PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH" ./node_modules/.bin/vitest run components/button
```

5/5 tests passed (1 老 + 4 新)。

## 改动文件

3 files / 55+ / 2-

Closes #733