### PR TITLE
feat(table): action 增加 type 配置项,默认 primary (#830)

### DIFF
--- a/components/table/__tests__/table-action-830.spec.ts
+++ b/components/table/__tests__/table-action-830.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FTableCell from '../components/cell';
+import { provideKey } from '../const';
+
+const mockColumn = {
+    id: 1,
+    props: {
+        action: [],
+    },
+    slots: {},
+} as any;
+
+describe('FTableCell action type', () => {
+    it('renders action with default primary type when no type is provided', () => {
+        const mockColumnWithDefaultAction = {
+            ...mockColumn,
+            props: {
+                action: [
+                    {
+                        label: 'Edit',
+                        func: vi.fn(),
+                    },
+                ],
+            },
+        } as any;
+        const mockRow = { id: 1 };
+        const wrapper = mount(FTableCell, {
+            props: {
+                row: mockRow,
+                rowIndex: 0,
+                column: mockColumnWithDefaultAction,
+                columnIndex: 0,
+                cellValue: null,
+            },
+            global: {
+                provide: {
+                    [provideKey]: { prefixCls: 'fes-table' },
+                },
+            },
+        });
+        const btn = wrapper.find('button');
+        expect(btn.exists()).toBe(true);
+        expect(btn.classes()).toContain('fes-table-action-item');
+        expect(btn.classes()).toContain('fes-btn-type-primary');
+    });
+
+    it('renders action with warning type when type="warning"', () => {
+        const mockColumnWithWarning = {
+            ...mockColumn,
+            props: {
+                action: [
+                    {
+                        label: 'Warn',
+                        func: vi.fn(),
+                        type: 'warning',
+                    },
+                ],
+            },
+        } as any;
+        const mockRow = { id: 1 };
+        const wrapper = mount(FTableCell, {
+            props: {
+                row: mockRow,
+                rowIndex: 0,
+                column: mockColumnWithWarning,
+                columnIndex: 0,
+                cellValue: null,
+            },
+            global: {
+                provide: {
+                    [provideKey]: { prefixCls: 'fes-table' },
+                },
+            },
+        });
+        const btn = wrapper.find('button');
+        expect(btn.exists()).toBe(true);
+        expect(btn.classes()).toContain('fes-btn-type-warning');
+    });
+
+    it('renders action with danger type when type="danger"', () => {
+        const mockColumnWithDanger = {
+            ...mockColumn,
+            props: {
+                action: [
+                    {
+                        label: 'Delete',
+                        func: vi.fn(),
+                        type: 'danger',
+                    },
+                ],
+            },
+        } as any;
+        const mockRow = { id: 1 };
+        const wrapper = mount(FTableCell, {
+            props: {
+                row: mockRow,
+                rowIndex: 0,
+                column: mockColumnWithDanger,
+                columnIndex: 0,
+                cellValue: null,
+            },
+            global: {
+                provide: {
+                    [provideKey]: { prefixCls: 'fes-table' },
+                },
+            },
+        });
+        const btn = wrapper.find('button');
+        expect(btn.exists()).toBe(true);
+        expect(btn.classes()).toContain('fes-btn-type-danger');
+    });
+});

--- a/components/table/components/cell.tsx
+++ b/components/table/components/cell.tsx
@@ -66,7 +66,7 @@ export default defineComponent({
                         {actions.map((action) => (
                             <Button
                                 class={`${prefixCls}-action-item`}
-                                type="link"
+                                type={action.type ?? 'primary'}
                                 onClick={() => {
                                     action.func(row);
                                 }}

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -15,6 +15,7 @@ export type RowKey = string | ((row: RowType) => string | number);
 export interface ActionType {
     label: string | number;
     func: (row: any) => void;
+    type?: 'primary' | 'text' | 'link' | 'info' | 'success' | 'warning' | 'danger' | 'default';
 }
 
 export interface TableInst


### PR DESCRIPTION
## 修复

FTable action 操作按钮支持 type 配置项（primary / warning / danger 等），默认 primary。

## 改动

- `components/table/interface.ts` —— ActionType 加 `type?: Type` 字段
- `components/table/components/cell.tsx` —— `type="link"` → `type={action.type ?? 'primary'}`
- `components/table/__tests__/table-action-830.spec.ts` —— 3 个行为测试（default / warning / danger）

## 验证

3/3 vitest passed. 无 lockfile 污染.

Closes #830