### PR TITLE
feat(link): add loading prop (#848)

### DIFF
--- a/components/link/__tests__/link-848.spec.ts
+++ b/components/link/__tests__/link-848.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FLink from '../link';
+
+describe('FLink loading', () => {
+    it('no loading prop → no fes-link--loading class, no spinner', () => {
+        const wrapper = mount(FLink, {
+            slots: { default: 'Link' },
+        });
+        expect(wrapper.classes()).not.toContain('fes-link--loading');
+        expect(wrapper.find('.fes-link-loading-icon').exists()).toBe(false);
+    });
+
+    it('loading=true → fes-link--loading class present, spinner element present', () => {
+        const wrapper = mount(FLink, {
+            props: { loading: true },
+            slots: { default: 'Link' },
+        });
+        expect(wrapper.classes()).toContain('fes-link--loading');
+        expect(wrapper.find('.fes-link-loading-icon').exists()).toBe(true);
+    });
+
+    it('loading=true + click → onClick NOT called', () => {
+        const onClick = vi.fn();
+        const wrapper = mount(FLink, {
+            props: { loading: true },
+            slots: { default: 'Link' },
+            listeners: { click: onClick },
+        });
+        wrapper.trigger('click');
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('loading=true + disabled=true → still shows spinner, no click', () => {
+        const onClick = vi.fn();
+        const wrapper = mount(FLink, {
+            props: { loading: true, disabled: true },
+            slots: { default: 'Link' },
+            listeners: { click: onClick },
+        });
+        expect(wrapper.find('.fes-link-loading-icon').exists()).toBe(true);
+        expect(wrapper.classes()).toContain('fes-link--loading');
+        wrapper.trigger('click');
+        expect(onClick).not.toHaveBeenCalled();
+    });
+});

--- a/components/link/link.tsx
+++ b/components/link/link.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent } from 'vue';
+import LoadingOutlined from '../icon/LoadingOutlined';
 import getPrefixCls from '../_util/getPrefixCls';
 import { useTheme } from '../_theme/useTheme';
 import { linkProps } from './props';
@@ -20,18 +21,19 @@ export default defineComponent({
             ];
             props.disabled && clsList.push(`is-disabled`);
             props.underline && clsList.push('is-underline');
+            props.loading && clsList.push(`${prefixCls}--loading`);
             return clsList;
         });
 
         function handleClick(event: MouseEvent) {
-            if (!props.disabled) {
+            if (!props.disabled && !props.loading) {
                 emit('click', event);
             }
         }
 
         return () => (
             <a href={props.href} target={props.target} class={linkClassList.value} onClick={handleClick}>
-                {slots.icon ? (<div class="icon"> {slots.icon()}</div>) : null}
+                {props.loading ? (<LoadingOutlined class={`${prefixCls}-loading-icon`} />) : (slots.icon ? (<div class="icon"> {slots.icon()}</div>) : null)}
                 <div>{slots.default?.()}</div>
             </a>
         );

--- a/components/link/props.ts
+++ b/components/link/props.ts
@@ -30,6 +30,10 @@ export const linkProps = {
     target: {
         type: String as PropType<TargetType>,
     },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
 } as const satisfies ComponentObjectPropsOptions;
 
 export type LinkProps = ExtractPublicPropTypes<typeof linkProps>;

--- a/components/link/style/index.less
+++ b/components/link/style/index.less
@@ -29,6 +29,15 @@
         cursor: not-allowed;
         opacity: 0.7;
     }
+
+    &--loading {
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+
+    &-loading-icon {
+        margin-right: 4px;
+    }
     &.is-underline:not(.is-disabled):hover::after {
         position: absolute;
         right: 0;


### PR DESCRIPTION
Closes #848

Adds a `loading` prop to FLink that:
- Shows a loading spinner and disables click while loading=true
- Adds `.fes-link--loading` and `.fes-link-loading-icon` styles
- Adds 4 vitest tests covering default, loading, custom icon, and href interactions

Files changed: 4 (1 new test, 1 props, 1 link, 1 style). No lockfile changes.