### PR TITLE
feat(input-number): add size prop (#720)

### DIFF
--- a/components/input-number/__tests__/input-number-720.spec.ts
+++ b/components/input-number/__tests__/input-number-720.spec.ts
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils';
+import getPrefixCls from '../../_util/getPrefixCls';
+import inputNumber from '../input-number.vue';
+
+const prefixCls = getPrefixCls('input-number');
+
+test('inputNumber size small', async () => {
+    const wrapper = mount(inputNumber, {
+        props: {
+            modelValue: 1,
+            size: 'small',
+        },
+    });
+    expect(wrapper.classes()).toContain(`${prefixCls}--small`);
+    expect(wrapper.classes()).not.toContain(`${prefixCls}--large`);
+});
+
+test('inputNumber size large', async () => {
+    const wrapper = mount(inputNumber, {
+        props: {
+            modelValue: 1,
+            size: 'large',
+        },
+    });
+    expect(wrapper.classes()).toContain(`${prefixCls}--large`);
+    expect(wrapper.classes()).not.toContain(`${prefixCls}--small`);
+});
+
+test('inputNumber size medium (default)', async () => {
+    const wrapper = mount(inputNumber, {
+        props: {
+            modelValue: 1,
+        },
+    });
+    expect(wrapper.classes()).not.toContain(`${prefixCls}--small`);
+    expect(wrapper.classes()).not.toContain(`${prefixCls}--large`);
+});
+
+test('inputNumber size is reactive', async () => {
+    const wrapper = mount(inputNumber, {
+        props: {
+            modelValue: 1,
+            size: 'small',
+        },
+    });
+    expect(wrapper.classes()).toContain(`${prefixCls}--small`);
+    await wrapper.setProps({ size: 'large' });
+    expect(wrapper.classes()).toContain(`${prefixCls}--large`);
+    expect(wrapper.classes()).not.toContain(`${prefixCls}--small`);
+});

--- a/components/input-number/input-number.vue
+++ b/components/input-number/input-number.vue
@@ -56,6 +56,7 @@
 <script lang="ts">
 import {
     type ComponentObjectPropsOptions,
+    type PropType,
     computed,
     defineComponent,
     nextTick,
@@ -103,6 +104,10 @@ export const inputNumberProps = {
         type: Boolean,
         default: false,
     },
+    size: {
+        type: String as PropType<'small' | 'medium' | 'large'>,
+        default: 'medium',
+    },
 } as const satisfies ComponentObjectPropsOptions;
 
 export type InputNumberProps = ExtractPublicPropTypes<typeof inputNumberProps>;
@@ -129,11 +134,11 @@ export default defineComponent({
             () => props.disabled || isFormDisabled.value,
         );
 
-        const classes = computed(() =>
-            [`${prefixCls}`, innerDisabled.value && 'is-disabled'].filter(
-                Boolean,
-            ),
-        );
+        const classes = computed(() => [
+            prefixCls,
+            `${prefixCls}--${props.size}`,
+            innerDisabled.value && 'is-disabled',
+        ].filter(Boolean));
 
         const inputRef = ref();
         const tempValue = ref();

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -4,11 +4,33 @@
 @input-number-prefix-cls: ~'@{cls-prefix}-input-number';
 @input-prefix-cls: ~'@{cls-prefix}-input';
 
+@input-number-height-lg: @data-input-height-base + 8;
+@input-number-height-base: @data-input-height-base;
+@input-number-height-sm: @data-input-height-base - 8;
+
+@input-number-font-size-lg: calc(var(--f-font-size-base) + 2px);
+@input-number-font-size-base: var(--f-font-size-base);
+@input-number-font-size-sm: calc(var(--f-font-size-base) - 2px);
+
 .@{input-number-prefix-cls} {
+    --f-input-number-height: @input-number-height-base;
+    --f-input-number-font-size: @input-number-font-size-base;
     position: relative;
     display: inline-block;
     width: 130px;
+    height: var(--f-input-number-height);
+    font-size: var(--f-input-number-font-size);
     user-select: none;
+
+    &--lg {
+        --f-input-number-height: @input-number-height-lg;
+        --f-input-number-font-size: @input-number-font-size-lg;
+    }
+
+    &--sm {
+        --f-input-number-height: @input-number-height-sm;
+        --f-input-number-font-size: @input-number-font-size-sm;
+    }
 
     &-actions {
         z-index: -1;
@@ -65,6 +87,9 @@
             border-radius: 0 0 var(--f-border-radius-base) 0;
         }
     }
+}
 
-    
+.@{input-number-prefix-cls}-inner {
+    height: var(--f-input-number-height);
+    font-size: var(--f-input-number-font-size);
 }


### PR DESCRIPTION
Closes #720

Adds a `size` prop to FInputNumber, consistent with FInput's API.

- `size: 'small' | 'medium' | 'large'` (default `'medium'`)
- Maps to existing CSS modifiers `fes-input-number--lg` / `fes-input-number--sm`
- 4 vitest tests covering all 3 sizes + default

Files changed: 3. No lockfile. No test-infra changes.