### PR TITLE
test(form): add labelWidth propagation tests (#911)

### DIFF
--- a/components/form/__tests__/form-911.spec.ts
+++ b/components/form/__tests__/form-911.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { h, nextTick } from 'vue';
+import FForm from '../form.vue';
+import FFormItem from '../formItem.vue';
+
+describe('FForm labelWidth #911', () => {
+    it('FForm labelWidth propagates to FFormItem', async () => {
+        const wrapper = mount(FForm, {
+            props: { labelWidth: '100px' },
+            slots: {
+                default: () => [h(FFormItem, { label: 'Name' }, { default: () => 'input' })],
+            },
+        });
+        await nextTick();
+        const html = wrapper.html();
+        console.log('HTML:', JSON.stringify(html));
+        expect(html).toContain('width: 100px');
+    });
+
+    it('FFormItem own labelWidth overrides FForm labelWidth', async () => {
+        const wrapper = mount(FForm, {
+            props: { labelWidth: '80px' },
+            slots: {
+                default: () => [h(FFormItem, { label: 'Email', labelWidth: '120px' }, { default: () => 'input' })],
+            },
+        });
+        await nextTick();
+        const html = wrapper.html();
+        console.log('HTML:', JSON.stringify(html));
+        expect(html).toContain('width: 120px');
+    });
+});


### PR DESCRIPTION
Closes #911

The `labelWidth` prop was already implemented in FForm (interface.ts:46) and FFormItem already reads it via provide/inject and applies it as inline style on the label (formItem.vue:157-158). This PR adds 2 vitest tests to lock the existing behavior:

- FForm's `labelWidth` propagates to FFormItem
- FFormItem's own `labelWidth` overrides FForm's

Files changed: 1 (test only). No lockfile. No test-infra changes.