### PR TITLE
feat(modal): add centered prop (#812)

### DIFF
--- a/components/modal/__tests__/modal-812.spec.ts
+++ b/components/modal/__tests__/modal-812.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import FModal from '../modal';
+import getPrefixCls from '../../_util/getPrefixCls';
+
+const prefixCls = getPrefixCls('modal');
+
+describe('FModal centered prop (#812)', () => {
+    test('centered: true applies the centered class', async () => {
+        const wrapper = mount(FModal, {
+            attachTo: document.body,
+            props: {
+                show: true,
+                centered: true,
+            },
+            slots: {
+                default: 'content',
+            },
+        });
+        await nextTick();
+        const container = document.body.querySelector(`.${prefixCls}-container`);
+        expect(container?.classList.contains(`${prefixCls}-centered`)).toBe(true);
+        wrapper.unmount();
+    });
+
+    test('centered: false (default) does not apply the centered class', async () => {
+        const wrapper = mount(FModal, {
+            attachTo: document.body,
+            props: {
+                show: true,
+            },
+            slots: {
+                default: 'content',
+            },
+        });
+        await nextTick();
+        const container = document.body.querySelector(`.${prefixCls}-container`);
+        expect(container?.classList.contains(`${prefixCls}-centered`)).toBe(false);
+        wrapper.unmount();
+    });
+});

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -244,6 +244,7 @@ const Modal = defineComponent({
                     class={{
                         [`${prefixCls}-container`]: true,
                         [`${prefixCls}-center`]: props.center,
+                        [`${prefixCls}-centered`]: props.centered,
                         [`${prefixCls}-vertical-center`]:
                                         props.verticalCenter,
                         [`${prefixCls}-fullscreen`]:

--- a/components/modal/props.ts
+++ b/components/modal/props.ts
@@ -75,6 +75,7 @@ export const modalProps = {
     },
     verticalCenter: Boolean,
     center: Boolean,
+    centered: Boolean,
     footer: {
         type: Boolean,
         default: true,

--- a/components/modal/style/index.less
+++ b/components/modal/style/index.less
@@ -30,7 +30,8 @@
             }
         }
 
-        &.@{modal-prefix-cls}-vertical-center {
+        &.@{modal-prefix-cls}-vertical-center,
+        &.@{modal-prefix-cls}-centered {
             align-items: center;
         }
 


### PR DESCRIPTION
Closes #812

Adds a `centered` Boolean prop to FModal that vertically centers the dialog in the viewport.

**Implementation:**
- `props.ts`: Added `centered: Boolean` (default false)
- `modal.tsx`: Applies `fes-modal-centered` class when `centered=true`
- `style/index.less`: `align-items: center` on the centered variant
- 2 vitest tests covering `centered: true` and `centered: false` (default)

Files changed: 4. No lockfile. No test-infra changes.