### PR TITLE
feat(switch): add loading prop (#914)

### DIFF
--- a/components/switch/__tests__/switch-914.spec.ts
+++ b/components/switch/__tests__/switch-914.spec.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils';
+import FSwitch from '../switch.vue';
+
+const prefixCls = 'fes-switch';
+
+describe('switch loading prop #914', () => {
+    test('loading: true shows the loading icon', async () => {
+        const wrapper = mount(FSwitch, {
+            props: {
+                modelValue: false,
+                loading: true,
+            },
+        });
+
+        const loadingIcon = wrapper.find(`.${prefixCls}-loading`);
+        expect(loadingIcon.exists()).toBe(true);
+    });
+
+    test('loading: true blocks click toggle', async () => {
+        const wrapper = mount(FSwitch, {
+            props: {
+                modelValue: false,
+                loading: true,
+            },
+        });
+
+        expect(wrapper.classes('is-checked')).toBe(false);
+
+        await wrapper.trigger('click');
+
+        expect(wrapper.classes('is-checked')).toBe(false);
+    });
+
+    test('loading: true shows loading icon in checked state', async () => {
+        const wrapper = mount(FSwitch, {
+            props: {
+                modelValue: true,
+                loading: true,
+            },
+        });
+
+        expect(wrapper.classes('is-checked')).toBe(true);
+        const loadingIcon = wrapper.find(`.${prefixCls}-loading`);
+        expect(loadingIcon.exists()).toBe(true);
+    });
+
+    test('loading: false does not show loading icon', async () => {
+        const wrapper = mount(FSwitch, {
+            props: {
+                modelValue: false,
+                loading: false,
+            },
+        });
+
+        const loadingIcon = wrapper.find(`.${prefixCls}-loading`);
+        expect(loadingIcon.exists()).toBe(false);
+    });
+
+    test('normal toggle works when loading is false', async () => {
+        const wrapper = mount(FSwitch, {
+            props: {
+                modelValue: false,
+                loading: false,
+            },
+        });
+
+        expect(wrapper.classes('is-checked')).toBe(false);
+
+        await wrapper.trigger('click');
+
+        expect(wrapper.classes('is-checked')).toBe(true);
+    });
+});

--- a/components/switch/switch.vue
+++ b/components/switch/switch.vue
@@ -55,6 +55,10 @@ export const switchProps = {
         type: String as PropType<SwitchSize>,
         default: 'normal',
     },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
 } as const satisfies ComponentObjectPropsOptions;
 
 export type SwitchProps = ExtractPublicPropTypes<typeof switchProps>;
@@ -87,7 +91,10 @@ export default defineComponent({
             }
         });
 
-        const loadingRef = ref(false);
+        const beforeChangeLoadingRef = ref(false);
+        const loadingRef = computed(
+            () => props.loading || beforeChangeLoadingRef.value,
+        );
 
         const handleChange = () => {
             ctx.emit(CHANGE_EVENT, currentValue.value);
@@ -108,18 +115,21 @@ export default defineComponent({
             if (innerDisabled.value) {
                 return;
             }
+            if (loadingRef.value) {
+                return;
+            }
             if (isFunction(props.beforeChange)) {
-                loadingRef.value = true;
+                beforeChangeLoadingRef.value = true;
                 try {
                     const confirm = await props.beforeChange(
                         currentValue.value,
                     );
-                    loadingRef.value = false;
+                    beforeChangeLoadingRef.value = false;
                     if (confirm === false) {
                         return;
                     }
                 } catch (e) {
-                    loadingRef.value = false;
+                    beforeChangeLoadingRef.value = false;
                     return;
                 }
             }


### PR DESCRIPTION
Closes #914

Adds a `loading` Boolean prop to FSwitch that shows a spinner and blocks toggling during async operations.

**Implementation:**
- `switch.vue`: `loading: Boolean` prop, renders LoadingOutlined spinner, blocks click toggle when true
- 5 vitest tests covering: loading icon visible, click blocked, checked/unchecked states, etc.

Files changed: 2. No lockfile. No test-infra changes.